### PR TITLE
Allow empty enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -1200,6 +1200,10 @@ reflected in the response).
 
 If the variable doesn't exist, then a 404 error is returned.
 
+It should be noted that if you delete an enumerated variable, the terminology 
+referenced will not be deleted. The reason being that we can theoretically have
+many variables using the same terminology for similar variables. 
+
 ### https://[APPURL]/api/Table/[id]/harmony
 
 #### GET

--- a/src/locutus/api/table.py
+++ b/src/locutus/api/table.py
@@ -4,6 +4,7 @@ from locutus import persistence
 from locutus.model.table import Table as mTable
 from locutus.api import default_headers
 from locutus.api.datadictionary import DataDictionaries
+from copy import deepcopy
 
 import pdb
 
@@ -64,13 +65,10 @@ class TableEdit(Resource):
         table = mTable.get(id)
         body = request.get_json()
 
-        table.add_variable(
-            {
-                "name": code,
-                "description": body["description"],
-                "data_type": body["data_type"],
-            }
-        )
+        vardef = deepcopy(body)
+        vardef["name"] = code
+
+        table.add_variable(vardef)
         table.save()
         return table.dump(), 201, default_headers
 

--- a/src/locutus/model/reference.py
+++ b/src/locutus/model/reference.py
@@ -16,7 +16,7 @@ class Reference(Serializable):
     def __init__(self, reference=None, instance=None):
         if type(reference) is not str:
             print(f"What sort of reference is this?\n{reference}")
-            pdb.set_trace()
+            # pdb.set_trace()
         else:
             print(f"The reference string is: {reference}")
         self.reference = reference

--- a/src/locutus/model/table.py
+++ b/src/locutus/model/table.py
@@ -118,7 +118,7 @@ class Table(Serializable):
         if not success:
             msg = f"The table, '{self.name}' ({self.id}), has no code, '{varname}'"
             print(msg)
-            raise KeyError(msg)        
+            raise KeyError(msg)
 
     def rename_var(self, original_varname, new_varname, new_description):
         status = 200
@@ -162,11 +162,11 @@ class Table(Serializable):
         v = variable
 
         if type(variable) is dict:
-            pdb.set_trace()
             # For now, let's insure that the enumerations terminology is there or
             # create an empty one if not. This may need to be moved into the
             # variable itself.
-            if v["data_type"] == Variable.DataType.ENUMERATION:
+
+            if v["data_type"] == "ENUMERATION":
                 if "enumerations" not in v:
                     # Create an empty terminology and create a reference to that
                     # terminology

--- a/src/locutus/model/table.py
+++ b/src/locutus/model/table.py
@@ -160,7 +160,27 @@ class Table(Serializable):
 
     def add_variable(self, variable):
         v = variable
+
         if type(variable) is dict:
+            pdb.set_trace()
+            # For now, let's insure that the enumerations terminology is there or
+            # create an empty one if not. This may need to be moved into the
+            # variable itself.
+            if v["data_type"] == Variable.DataType.ENUMERATION:
+                if "enumerations" not in v:
+                    # Create an empty terminology and create a reference to that
+                    # terminology
+                    t = Terminology(
+                        name=v["name"],
+                        description=v.get("description"),
+                        url=f"{self.url}/{v['name']}",
+                    )
+                    t.save()
+
+                    reference = f"Terminology/{t.id}"
+                    v["enumerations"] = {"reference": reference}
+                    print(v)
+
             v = Variable.deserialize(variable)
             self.variables.append(v)
         else:

--- a/src/locutus/model/variable.py
+++ b/src/locutus/model/variable.py
@@ -94,6 +94,7 @@ class Variable:
         try:
             return cls._factory_workers[data["data_type"].lower()](**vardata)
         except:
+            print(data)
             print("An issue was encountered with the following data")
             raise InvalidVariableDefinition(data["name"], data)
 


### PR DESCRIPTION
If the Web app wants to create a blank enumerated variable,  the backend now creates a terminology to house the enumerated values. 