### PR TITLE
Mapping crash

### DIFF
--- a/src/locutus/model/terminology.py
+++ b/src/locutus/model/terminology.py
@@ -856,7 +856,8 @@ class CodingMapping(Coding):
         self.user_input = user_input
         self.ftd_code = code # Default to given code, updated if necessary. 
 
-        FTDConceptMapTerminology().validate_codes_against(mapping_relationship, additional_enums=[""])
+        if mapping_relationship is not None:
+            FTDConceptMapTerminology().validate_codes_against(mapping_relationship, additional_enums=[""])
         self.mapping_relationship = mapping_relationship
 
     class _Schema(Schema):

--- a/src/locutus/model/terminology.py
+++ b/src/locutus/model/terminology.py
@@ -216,6 +216,10 @@ class Terminology(Serializable):
             cc.code = normalize_ftd_placeholders(cc.code)
 
             if cc.code == code:
+                # For now, if editor is none, we know this came from the database
+                # and it's not actually an error
+                if editor is None:
+                    return 
                 raise CodeAlreadyPresent(code, self.id, cc)
         new_coding = Coding(
             code=code, display=display, system=self.url, description=description


### PR DESCRIPTION
I added some checks to verify that our mapping relationships were valid at all points, but forgot to take into account that a large portion of our old mappings predate that and, therefore, are missing the field. This makes prevents the exception that was being thrown. I also stripped out some unnecessary ERRORs in the log relating to loading the terminology from the database. 