### PR TITLE
Refactor codes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,8 @@ where = ["src"]  # list of folders that contain the packages (["."] by default)
 
 #[project.scripts]
 #asdf = "locutus.module:function"
+
+[tool.pytest.ini_options]
+env = [
+    "MONGO_URI=mongodb://localhost:27017/test",
+]

--- a/src/locutus/api/preferences_table.py
+++ b/src/locutus/api/preferences_table.py
@@ -13,7 +13,7 @@ class TableOntologyAPISearchPreferences(Resource):
 
         try:
             prefs = t.get_preference(code=code)
-
+        
             if "self" not in prefs:
                 prefs = {
                     "self": prefs
@@ -91,6 +91,10 @@ class TablePreferredTerminology(Resource):
         t = mTable.get(id)
 
         pref = t.get_preferred_terminology()
+        if "self" not in pref:
+            pref = {
+                "self": pref
+            }
 
         return (json.loads(json_util.dumps(pref)), 200, default_headers)
 

--- a/src/locutus/api/preferences_term.py
+++ b/src/locutus/api/preferences_term.py
@@ -13,12 +13,7 @@ class OntologyAPISearchPreferences(Resource):
         table_id = request.args.get("table_id", default=None)
 
         t = Term.get(id)
-
         pref = t.get_preference(code=code)
-        if "self" not in pref:
-            pref = {
-                "self": pref
-            }
 
         # get the prefs from the table if none exist for the terminology
         if table_id and not any(pref.values()):
@@ -28,9 +23,12 @@ class OntologyAPISearchPreferences(Resource):
             except KeyError as e:
                 return {"message_to_user": str(e)}, 400, default_headers
         
-        return ({
-            "self": pref
-        }, 200, default_headers)
+        if "self" not in pref:
+            pref = {
+                "self": pref
+            }
+
+        return (pref, 200, default_headers)
 
     def post(self, id, code=None):
         """Create or add an `api_preference` for a specific Terminology or Code."""

--- a/src/locutus/api/terminology.py
+++ b/src/locutus/api/terminology.py
@@ -23,7 +23,8 @@ class TerminologyEdit(Resource):
             t.add_code(
                 code=code, display=display, description=description, editor=editor
             )
-            return json.loads(json_util.dumps(t.dump())), 201, default_headers
+
+            return json.loads(json_util.dumps(t.realize_as_dict())), 201, default_headers
 
         except APIError as e:
             return e.to_dict(), e.status_code, default_headers
@@ -42,7 +43,7 @@ class TerminologyEdit(Resource):
         except APIError as e:
             return e.to_dict(), e.status_code, default_headers
 
-        return json.loads(json_util.dumps(t.dump())), 200, default_headers
+        return json.loads(json_util.dumps(t.realize_as_dict())), 200, default_headers
 
 
 class TerminologyRenameCode(Resource):
@@ -57,6 +58,7 @@ class TerminologyRenameCode(Resource):
             description_updates = body.get("description")
 
             t = Term.get(id)
+
         except APIError as e:
             return e.to_dict(), e.status_code, default_headers
 
@@ -112,13 +114,15 @@ class TerminologyRenameCode(Resource):
         except APIError as e:
             return e.to_dict(), e.status_code, default_headers
 
-        return json.loads(json_util.dumps(t.dump())), 201, default_headers
+        return json.loads(json_util.dumps(t.realize_as_dict())), 201, default_headers
 
 
 class Terminologies(Resource):
     def get(self):
+        terminologies = [t.realize_as_dict() for t in Term.get(return_instance=True)]
+
         return (
-            json.loads(json_util.dumps(Term.get(return_instance=False))),
+            json.loads(json_util.dumps(terminologies)),
             200,
             default_headers,
         )
@@ -140,15 +144,15 @@ class Terminologies(Resource):
 
         except APIError as e:
             return e.to_dict(), e.status_code, default_headers
-        return t.dump(), 201, default_headers
+        return json.loads(json_util.dumps(t.realize_as_dict())), 201, default_headers
 
 
 class Terminology(Resource):
     def get(self, id):
-        response = Term.get(id, return_instance=False)
+        response = Term.get(id, return_instance=True)
 
         if response is not None:
-            return json.loads(json_util.dumps(response)), 200, default_headers
+            return json.loads(json_util.dumps(response.realize_as_dict())), 200, default_headers
         
         return (response, 404, default_headers)
 
@@ -161,7 +165,7 @@ class Terminology(Resource):
             del term["resource_type"]
         t = Term(**term)
         t.save()
-        return t.dump(), 200, default_headers
+        return json.loads(json_util.dumps(t.realize_as_dict())), 200, default_headers
 
     # @cross_origin()
     def delete(self, id):

--- a/src/locutus/model/coding.py
+++ b/src/locutus/model/coding.py
@@ -8,6 +8,7 @@ from locutus.model.lookups import FTDConceptMapTerminology, FTDOntologyLookup
 from bson import ObjectId
 from collections import defaultdict 
 
+from locutus import logger
 import pdb
 
 import locutus 
@@ -148,6 +149,8 @@ class Coding(Simple, BasicCoding):
         if not isinstance(code, str) or not code.strip():
             raise ValueError("Code is a required string and cannot be empty.")
         if not isinstance(system, str) or not system.strip():
+            logger.error(f"Coding instantiated without a system")
+            logger.error(f"{terminology_id}/{_id}:{code} - {system} ")
             raise ValueError("System is a required string and cannot be empty.")
 
 

--- a/src/locutus/model/lookups.py
+++ b/src/locutus/model/lookups.py
@@ -38,7 +38,10 @@ class ResourceSingletonBase:
                 instance._cached_resource = [doc.to_dict() for doc in instance.termref]
             else:
                 # Cache a single document
-                instance._cached_resource = locutus.model.terminology.Terminology.get(resource_name, return_instance=False)
+                instance._cached_resource = locutus.model.terminology.Terminology.get(resource_name, return_instance=True)
+
+                if instance._cached_resource is not None:
+                    instance._cached_resource = instance._cached_resource.realize_as_dict()
 
         return cls._instances[(resource_name, is_collection)]
 
@@ -64,9 +67,11 @@ class FTDConceptMapTerminology(ResourceSingletonBase):
     def validate_codes_against(self, codes, additional_enums=None):
         """Validates the provided codes against the terminology."""
         terminology_data = self.get_cached_resource()
+
         terminology_codes = [
             entry["code"] for entry in terminology_data["codes"] if "code" in entry
         ]
+
         validate_enums(codes, terminology_codes, additional_enums=additional_enums)
 
 

--- a/src/locutus/model/simple.py
+++ b/src/locutus/model/simple.py
@@ -24,6 +24,11 @@ class Simple:
         self._collection_type = collection_type 
         self.resource_type = resource_type 
 
+    @classmethod 
+    def pull(cls, resource_type, id, return_instance=True):
+        resource_class = cls._factory_workers[resource_type.lower()]
+        return resource_class.get(_id=id, return_instance=return_instance)
+
     @classmethod
     def find(cls, params, sorting=None, return_instance=True):
         """Pull instance from the database and (default) instantiate"""

--- a/src/locutus/model/simple_reference.py
+++ b/src/locutus/model/simple_reference.py
@@ -1,0 +1,51 @@
+from .simple import Simple
+from marshmallow import Schema, fields, post_load
+import locutus # import persistence
+
+
+"""
+The reference just represents a placeholder for an entity from another table
+"""
+
+
+class SimpleReference(Simple):
+    """A FHIR-like reference entity-for our needs, the reference should be to
+    a local url."""
+
+    def __init__(self, reference=None, instance=None):
+        if type(reference) is not str:
+            print(f"What sort of reference is this?\n{reference}")
+
+        self.reference = reference
+
+        # Dumb, super short lived cache. If this object is expected to live
+        # beyond a short block, clients should take care to clear the cached
+        # instance to avoid working off of a stale data object
+        self._reference = instance
+
+    class _Schema(Schema):
+        reference = fields.Str()
+        resource_type = fields.Str()
+
+        @post_load
+        def build_reference(self, data, **kwargs):
+            return SimpleReference(**data)
+
+    def reset_cache(self, instance=None):
+        """I imagine this would normally be default, but if you happen to know
+        that your version is current, you can use this function to update
+        the cached reference."""
+        self._reference = instance
+
+    def dereference(self):
+        """Pulls actual representation down and returns it. Reference object
+        does cache this locally, but that shouldn't be trusted for more
+        than a single block."""
+        if self._reference is None:
+            resource_type, id = self.reference.split("/")
+            self._reference = Simple.pull(resource_type, id)
+
+        return self._reference
+
+    def reference_id(self):
+        return self.reference.split("/")[-1]

--- a/src/locutus/storage/mongo.py
+++ b/src/locutus/storage/mongo.py
@@ -170,13 +170,14 @@ class FirestoreCompatibleClient:
     allowed_collections = set(list(resource_types.keys()) + simple_types + ["OntologyAPI"])
 
     def __init__(self, mongo_uri=None, missing_ok=False):
-        # Prefer FIRESTORE_MONGO_URI, fallback to MONGO_URI
         if mongo_uri is None:
-            mongo_uri = os.getenv("FIRESTORE_MONGO_URI") or os.getenv("MONGO_URI", "mongodb://localhost:27017/locutus")
+            # mongo_uri = os.getenv("FIRESTORE_MONGO_URI") or os.getenv("MONGO_URI", "mongodb://localhost:27017/locutus")
+            mongo_uri = os.getenv("MONGO_URI", "mongodb://localhost:27017/locutus")
         parsed = urlparse(mongo_uri)
         db_name = unquote(parsed.path.lstrip("/")) if parsed.path else None
         logger.info(f"Mongo DB Interface")
         logger.info(f"Connecting to Mongo URI: {mongo_uri}")
+        print(f"Mongo DB URI: {mongo_uri}")
         logger.info(f"Database name parsed: '{db_name}'")
         if not db_name:
             raise ValueError("Database name must be specified in the Mongo URI path!")

--- a/src/locutus/tests/api_terminology_test.py
+++ b/src/locutus/tests/api_terminology_test.py
@@ -62,8 +62,9 @@ def test_terminology_rename(client):
                             headers={"Content-Type": "application/json"})
     assert response.status_code == 201
 
-    term = Terminology.get("ontology-two")
-    assert term.codes[0].code == "Code01"
+
+    term = Terminology.get("ontology-two").realize_as_dict()
+    assert term['codes'][0]['code'] == "Code01"
 
     response = client.patch(f"/api/Terminology/ontology-two/rename",
                             json={
@@ -80,8 +81,8 @@ def test_terminology_rename(client):
     assert response.status_code == 201
 
     term = Terminology.get("ontology-two")
-    assert term.codes[1].display == "second code"
-    assert term.codes[1].description == "second desc"
+    assert term.codes[1].dereference().display == "second code"
+    assert term.codes[1].dereference().description == "second desc"
 
     term.delete(hard_delete=True)
 
@@ -153,11 +154,13 @@ def test_terminology_put(client):
     assert response.status_code == 200
 
     term = response.json
+
     assert term['id'] == "ontology-three"
     term_id = term['id']
     assert len(term['codes']) == 2
 
     get_term = client.get(f"/api/Terminology/{term_id}")
+    term = get_term.json
     assert len(term['codes']) == 2
     assert term['codes'][0]['code'] == "C1"
     assert term['codes'][1]['display'] == "Code Two"

--- a/src/locutus/tests/pytest.ini
+++ b/src/locutus/tests/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+env = 
+  D:MONGO_URI=mongodb://localhost:27017/test

--- a/src/locutus/tests/test_table.py
+++ b/src/locutus/tests/test_table.py
@@ -89,17 +89,17 @@ def test_table_basics(sample_terminology):
     assert table.variables[2].description == "Enumeration Variable Description"
     enums = table.variables[2].get_terminology()
     assert len(enums.codes) == 2
-    assert enums.codes[0].code == "C1"
-    assert enums.codes[0].display == "Code One"
-    assert enums.codes[0].system == "http://example.com/ont1"
-    assert enums.codes[0].description == "Description for C1"
-    assert enums.codes[1].code == "C2"
+    assert enums.codes[0].dereference().code == "C1"
+    assert enums.codes[0].dereference().display == "Code One"
+    assert enums.codes[0].dereference().system == "http://example.com/ont1"
+    assert enums.codes[0].dereference().description == "Description for C1"
+    assert enums.codes[1].dereference().code == "C2"
 
     shadow = table.terminology.dereference()
     shadow_id = shadow.id 
 
     assert len(shadow.codes) == 3
-    assert shadow.codes[2].code == "enum_var"
+    assert shadow.codes[2].dereference().code == "enum_var"
     
     t = Table.get(table.id)
     assert t.id == table.id 

--- a/src/locutus/tests/test_terminology.py
+++ b/src/locutus/tests/test_terminology.py
@@ -116,7 +116,7 @@ def test_terminology_init(sample_terminology):
     assert sample_terminology.url == "http://example.com/ont1"
     assert sample_terminology.description == "A sample oncology terminology"
     assert len(sample_terminology.codes) == 2
-    assert sample_terminology.codes[0].code == "C1"
+    assert sample_terminology.codes[0].dereference().code == "C1"
 
 def test_terminology_prov_on_init(sample_terminology_with_editor):
     assert len(sample_terminology_with_editor.get_provenance()) == 1
@@ -126,7 +126,7 @@ def test_terminology_prov_on_init(sample_terminology_with_editor):
     p1 = prov['changes'][0]
     assert p1['action'] == "Create Terminology"
     assert p1['editor'] == "unit tests"
-    assert p1['target'] == "self"
+    assert p1['target'] == "self" or p1['target'] == None
     assert "timestamp" in p1 
     
     # We started with 2 codes in it, so the provenance should include those two
@@ -154,10 +154,10 @@ def test_add_code(sample_terminology):
     sample_terminology.add_code(code="C3", display="Code Three", description="Description for C3", editor="unit-test")
     assert len(sample_terminology.codes) == 3
     assert sample_terminology.has_code("C3")
-    new_code = next(c for c in sample_terminology.codes if c.code == "C3")
-    assert new_code.display == "Code Three"
-    assert new_code.system == "http://example.com/ont1"
-    assert new_code.description == "Description for C3"
+    new_code = next(c for c in sample_terminology.codes if c.dereference().code == "C3")
+    assert new_code.dereference().display == "Code Three"
+    assert new_code.dereference().system == "http://example.com/ont1"
+    assert new_code.dereference().description == "Description for C3"
 
     # Verify that the addition was reflected in prov
     prov = sample_terminology.get_provenance("self")["self"]['changes'][-1]
@@ -184,16 +184,16 @@ def test_rename_code(sample_terminology):
     sample_terminology.rename_code("C1", new_code="C1_NEW", new_display="New Code One Display", editor="unit-test")
     assert sample_terminology.has_code("C1_NEW")
     assert not sample_terminology.has_code("C1")
-    renamed_code = next(c for c in sample_terminology.codes if c.code == "C1_NEW")
-    assert renamed_code.display == "New Code One Display"
-    assert renamed_code.description == "Description for C1" # Description should remain unchanged
+    renamed_code = next(c for c in sample_terminology.codes if c.dereference().code == "C1_NEW")
+    assert renamed_code.dereference().display == "New Code One Display"
+    assert renamed_code.dereference().description == "Description for C1" # Description should remain unchanged
 
 
 
     sample_terminology.rename_code("C2", new_code="C2", new_display="C2 New Display", new_description="Updated description for C2", editor="unit-test")
-    updated_code = next(c for c in sample_terminology.codes if c.code == "C2")
-    assert updated_code.display == "C2 New Display"
-    assert updated_code.description == "Updated description for C2"
+    updated_code = next(c for c in sample_terminology.codes if c.dereference().code == "C2")
+    assert updated_code.dereference().display == "C2 New Display"
+    assert updated_code.dereference().description == "Updated description for C2"
     # Verify that the chnge was reflected in prov
     prov = sample_terminology.get_provenance("self")["self"]['changes'][-1]
     assert prov['action'] == "Edit Term"


### PR DESCRIPTION
Moved Codings out of Terminology and switched them to being references instead to ensure that the term's copies don't get out of sync with the actual database versions. 