### PR TITLE
One code only

### DIFF
--- a/src/locutus/api/terminology.py
+++ b/src/locutus/api/terminology.py
@@ -21,7 +21,7 @@ class TerminologyEdit(Resource):
 
             t = Term.get(id)
             t.add_code(
-                code=code, display=display, description=description, editor=editor
+                code=code, display=display, description=description, editor=editor, exists_ok=False
             )
 
             return json.loads(json_util.dumps(t.realize_as_dict())), 201, default_headers

--- a/src/locutus/model/terminology.py
+++ b/src/locutus/model/terminology.py
@@ -228,7 +228,7 @@ class Terminology(Serializable):
                     coding.valid = True 
                     coding.save()
                 elif not exists_ok:
-                    raise locutus.model.exceptions.CodeAlreadyPresent(code, self.id, coding.dump())
+                    raise locutus.model.exceptions.CodeAlreadyPresent(code, self.id, coding)
                 
                 if new_to_codes:
                     self.codes.append(SimpleReference(f"Coding/{coding.id}"))

--- a/src/locutus/tests/api_terminology_test.py
+++ b/src/locutus/tests/api_terminology_test.py
@@ -219,6 +219,12 @@ def test_terminology_add_and_delete_code(client):
 
     new_coding_id = term['codes'][2]['id']
 
+    response = client.put(f"/api/Terminology/ontology-three/code/{new_code['code']}",
+                            json=new_code, 
+                            headers={"Content-Type": "application/json"})
+    assert response.status_code == 400 
+    assert response.json['message'][0:31] == "The code(C3) is already present"
+
     response = client.delete(f"/api/Terminology/ontology-three/code/{new_code['code']}",
                             json={"editor": "unit-test"})
     assert response.status_code == 200 

--- a/src/locutus/tests/test_terminology.py
+++ b/src/locutus/tests/test_terminology.py
@@ -3,7 +3,7 @@ import json
 from locutus.model.terminology import Terminology
 from locutus.model.global_id import GlobalID
 from locutus.model.coding import Coding, CodingMapping
-from locutus.model.exceptions import InvalidValueError
+from locutus.model.exceptions import InvalidValueError, CodeAlreadyPresent
 
 import pdb
 from rich import print
@@ -151,7 +151,7 @@ def test_build_code_dict(sample_terminology):
     assert code_dict["C2"].code == "C2"
 
 def test_add_code(sample_terminology):
-    sample_terminology.add_code(code="C3", display="Code Three", description="Description for C3", editor="unit-test")
+    sample_terminology.add_code(code="C3", display="Code Three", description="Description for C3", editor="unit-test", exists_ok=False)
     assert len(sample_terminology.codes) == 3
     assert sample_terminology.has_code("C3")
     new_code = next(c for c in sample_terminology.codes if c.dereference().code == "C3")
@@ -163,6 +163,10 @@ def test_add_code(sample_terminology):
     prov = sample_terminology.get_provenance("self")["self"]['changes'][-1]
     assert prov['action'] == "Add Term"
     assert prov['new_value'] == "C3"
+
+    # Verify that we can't add the same code twice
+    with pytest.raises(CodeAlreadyPresent) as e_info:
+        sample_terminology.add_code(code="C3", display="Code Three", description="Description for C3", editor="unit-test", exists_ok=False)
 
 def test_remove_code(sample_terminology):
     sample_terminology.remove_code("C1", editor="unit-test")


### PR DESCRIPTION
Add checks to prevent adding duplicate codes in a terminology when adding new codes (this does not prevent loading pre-existing terminologies with duplicate codes). 