### PR TITLE
Add code into init function like it should be

### DIFF
--- a/src/locutus/model/variable.py
+++ b/src/locutus/model/variable.py
@@ -169,7 +169,7 @@ class BooleanVariable(Variable):
     data_type = Variable.DataType.BOOLEAN
 
     def __init__(self, code="", name="", description=None):
-        super().__init__(name, description)
+        super().__init__(code=code, name=name, description=description)
         self.data_type = Variable.DataType.BOOLEAN
 
     class _Schema(Schema):


### PR DESCRIPTION
Descriptions for boolean vars that don't have a code were incorrectly being assigned to variable name. This is no longer true.