### PR TITLE
Type hints 1

### DIFF
--- a/deploy.py
+++ b/deploy.py
@@ -29,9 +29,7 @@ def main():
             "submit",
             "--region=" + args.region,
             "--config=cloudbuild.yaml",
-            "--substitutions=_PROJECT_ID={},_IMAGE_NAME={},_SERVICE_NAME={},_REGION={}".format(
-                args.project, args.image, args.service, args.region
-            ),
+            f"--substitutions=_PROJECT_ID={args.project},_IMAGE_NAME={args.image},_SERVICE_NAME={args.service},_REGION={args.region}",
         ],
         check=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = ["marshmallow",
+                "cachelib",
                 "flask",
                 "flask-cors",
                 "flask-restful",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,14 @@ target-version = "py313"
 # Test modules import fixtures across files for pytest to discover/inject them
 "src/locutus/tests/*.py" = ["F401", "F811"]
 
+[tool.basedpyright]
+# "standard" (the default) treats missing/incomplete type annotations as
+# errors, which floods an untyped codebase with noise unrelated to actual
+# bugs. "basic" keeps the substantive checks (attribute access, None
+# handling, argument/call type mismatches) while we incrementally add
+# annotations. Revisit once real findings are near zero.
+typeCheckingMode = "basic"
+
 [tool.setuptools_scm]
 version_file = "src/locutus/_version.py"
 

--- a/src/locutus/__init__.py
+++ b/src/locutus/__init__.py
@@ -12,7 +12,9 @@ from pathlib import Path
 from flask import g, has_request_context
 
 try:
-    from pythonjsonlogger import jsonlogger
+    # Only installed via the "cloud" extra (see pyproject.toml), not "dev" -
+    # unresolvable in a plain dev environment/type-checker by design.
+    from pythonjsonlogger import jsonlogger  # pyright: ignore[reportMissingImports]
 
     HAS_JSON_LOGGER = True
 except ImportError:
@@ -55,7 +57,7 @@ class RequestIDFilter(logging.Filter):
         return True
 
 
-def setup_logging(level="INFO", log_file="output/log.txt"):
+def setup_logging(level: str | int = "INFO", log_file: str | None = "output/log.txt"):
     """If rich is installed and we are running inside a tty, we'll use rich's
     built in handler for logging and will simplify the format since otherwise,
     there is duplicated information.

--- a/src/locutus/__init__.py
+++ b/src/locutus/__init__.py
@@ -8,7 +8,6 @@ import sys
 import traceback
 from os import getenv
 from pathlib import Path
-from typing import Callable, DefaultDict, Dict, List, TypeVar
 
 from flask import g, has_request_context
 
@@ -30,6 +29,8 @@ try:
     IS_RICH = True
 except ImportError:
     IS_RICH = False
+
+logger = logging.getLogger(__name__)
 
 
 def is_interactive():
@@ -171,7 +172,7 @@ def get_code_index(code):
       code_index(str):
       Examples: `given0x2Fcode' or <FTD-DOT-DOT>`
     """
-    logging.warning(f"get_code_index call: \n{''.join(traceback.format_stack()[-2])}")
+    logger.warning(f"get_code_index call: \n{''.join(traceback.format_stack()[-2])}")
     return code
     # Ensure any codes with designated placeholders have them in place at indexing.
     if code in REVERSE_FTD_PLACEHOLDERS:
@@ -201,7 +202,7 @@ def format_ftd_code(code, curie):
     if code and curie == "":
         return code
     else:
-        logging.warning(
+        logger.warning(
             f"Something went wrong trying to format the ftd_code. {curie}:{code}"
         )
         return code
@@ -230,4 +231,4 @@ def init_base_storage(filepath="db"):
 # at class-definition time, which transitively imports locutus.api, which
 # needs get_code_index (defined above) from this module. Importing storage
 # any earlier in this file creates a circular import.
-from .storage import persistence  # noqa: E402
+from .storage import persistence

--- a/src/locutus/api/__init__.py
+++ b/src/locutus/api/__init__.py
@@ -1,5 +1,5 @@
-from locutus.sessions import SessionManager
 from locutus import get_code_index
+from locutus.sessions import SessionManager
 
 default_headers = [
     ("Content-Type", "application/fhir+json"),
@@ -17,7 +17,7 @@ def delete_collection(collection, batch_size=100):
         docs = collection.list_documents(page_size=batch_size)
         for doc in docs:
             doc.delete()
-            del_count += 1
+            del_count += 1  # noqa: SIM113 - also drives the outer while loop, not just an index
             total_deleted += 1
 
     return total_deleted

--- a/src/locutus/api/combined_harmony.py
+++ b/src/locutus/api/combined_harmony.py
@@ -1,13 +1,14 @@
 """Generic Harmony export that allows users to specify one or more IDs to add to a single harmony result"""
 
-from flask_restful import Resource
-from flask import request
-from locutus.model.study import build_combined_harmony
-from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
-from locutus.api import default_headers
+import json
 
 from bson import json_util
-import json
+from flask import request
+from flask_restful import Resource
+
+from locutus.api import default_headers
+from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
+from locutus.model.study import build_combined_harmony
 
 
 class CombinedHarmony(Resource):

--- a/src/locutus/api/combined_harmony.py
+++ b/src/locutus/api/combined_harmony.py
@@ -20,10 +20,8 @@ class CombinedHarmony(Resource):
         table_ids = request.args.get("tables", "")
 
         try:
-            if data_format:
-                data_format = HarmonyFormat(data_format)
-            if file_format:
-                file_format = HarmonyOutputFormat(file_format)
+            data_format = HarmonyFormat(data_format)
+            file_format = HarmonyOutputFormat(file_format)
 
             harmony = build_combined_harmony(
                 study_ids=study_ids,

--- a/src/locutus/api/datadictionary.py
+++ b/src/locutus/api/datadictionary.py
@@ -1,14 +1,14 @@
-from flask_restful import Resource
-from flask import request
-from locutus.model.datadictionary import DataDictionary as DD
-from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
-from locutus.api.study import Studies
-from locutus.api import default_headers
-
-from flask_cors import cross_origin
+import json
 
 from bson import json_util
-import json
+from flask import request
+from flask_cors import cross_origin
+from flask_restful import Resource
+
+from locutus.api import default_headers
+from locutus.api.study import Studies
+from locutus.model.datadictionary import DataDictionary as DD
+from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
 
 
 class DataDictionaries(Resource):

--- a/src/locutus/api/metadata.py
+++ b/src/locutus/api/metadata.py
@@ -1,5 +1,7 @@
 import os
+
 from flask_restful import Resource
+
 from locutus._version import __version__
 
 

--- a/src/locutus/api/preferences_table.py
+++ b/src/locutus/api/preferences_table.py
@@ -69,7 +69,7 @@ class TableOntologyAPISearchPreferences(Resource):
 
 
 class TablePreferredTerminology(Resource):
-    def get(self, id=None):
+    def get(self, id: str):
         """
         Retrieve the preferred terminology for a specific Terminology
 
@@ -89,6 +89,12 @@ class TablePreferredTerminology(Resource):
         }
         """
         t = mTable.get(id)
+        if t is None:
+            return (
+                {"message_to_user": f"No table found with id {id}"},
+                404,
+                default_headers,
+            )
 
         pref = t.get_preferred_terminology()
 

--- a/src/locutus/api/preferences_table.py
+++ b/src/locutus/api/preferences_table.py
@@ -1,10 +1,12 @@
-from flask_restful import Resource
+import json
+
+from bson import json_util
 from flask import request
-from locutus.model.table import Table as mTable
+from flask_restful import Resource
+
 from locutus.api import default_headers, get_editor
 from locutus.model.exceptions import APIError, LackingUserID
-from bson import json_util
-import json
+from locutus.model.table import Table as mTable
 
 
 class TableOntologyAPISearchPreferences(Resource):
@@ -14,9 +16,8 @@ class TableOntologyAPISearchPreferences(Resource):
         try:
             prefs = t.get_preference(code=code)
 
-            if code is None:
-                if "self" not in prefs:
-                    prefs = {"self": prefs}
+            if code is None and "self" not in prefs:
+                prefs = {"self": prefs}
         except KeyError as e:
             return {"message_to_user": str(e)}, 400, default_headers
 

--- a/src/locutus/api/preferences_term.py
+++ b/src/locutus/api/preferences_term.py
@@ -1,9 +1,10 @@
-from flask_restful import Resource
 from flask import request
-from locutus.model.terminology import Terminology as Term
-from locutus.model.table import Table
-from locutus.model.exceptions import APIError, CodeNotPresent, LackingUserID
+from flask_restful import Resource
+
 from locutus.api import default_headers, get_editor
+from locutus.model.exceptions import APIError, CodeNotPresent, LackingUserID
+from locutus.model.table import Table
+from locutus.model.terminology import Terminology as Term
 
 
 class OntologyAPISearchPreferences(Resource):
@@ -23,9 +24,8 @@ class OntologyAPISearchPreferences(Resource):
             except KeyError as e:
                 return {"message_to_user": str(e)}, 400, default_headers
 
-        if code is None:
-            if "self" not in pref:
-                pref = {"self": pref}
+        if code is None and "self" not in pref:
+            pref = {"self": pref}
 
         return (pref, 200, default_headers)
 

--- a/src/locutus/api/preferences_term.py
+++ b/src/locutus/api/preferences_term.py
@@ -8,17 +8,29 @@ from locutus.model.terminology import Terminology as Term
 
 
 class OntologyAPISearchPreferences(Resource):
-    def get(self, id=None, code=None):
+    def get(self, id: str, code: str | None = None):
 
         # Optional parameter
         table_id = request.args.get("table_id", default=None)
 
         t = Term.get(id)
+        if t is None:
+            return (
+                {"message_to_user": f"No terminology found with id {id}"},
+                404,
+                default_headers,
+            )
         pref = t.get_preference(code=code)
 
         # get the prefs from the table if none exist for the terminology
         if table_id and not any(pref.values()):
             tb = Table.get(table_id)
+            if tb is None:
+                return (
+                    {"message_to_user": f"No table found with id {table_id}"},
+                    404,
+                    default_headers,
+                )
             try:
                 pref = tb.get_preference(code=code)
             except KeyError as e:
@@ -84,7 +96,7 @@ class OntologyAPISearchPreferences(Resource):
 
 
 class PreferredTerminology(Resource):
-    def get(self, id=None):
+    def get(self, id: str):
         """
         Retrieve the preferred terminology for a specific Terminology
 
@@ -107,12 +119,24 @@ class PreferredTerminology(Resource):
         table_id = request.args.get("table_id", default=None)
 
         t = Term.get(id)
+        if t is None:
+            return (
+                {"message_to_user": f"No terminology found with id {id}"},
+                404,
+                default_headers,
+            )
 
         pref = t.get_preferred_terminology()
 
         # get the prefs from the table if none exist for the terminology
         if table_id and not any(pref.values()):
             tb = Table.get(table_id)
+            if tb is None:
+                return (
+                    {"message_to_user": f"No table found with id {table_id}"},
+                    404,
+                    default_headers,
+                )
             try:
                 pref = tb.get_preferred_terminology()
             except KeyError as e:

--- a/src/locutus/api/provenance.py
+++ b/src/locutus/api/provenance.py
@@ -1,10 +1,11 @@
-from flask_restful import Resource
-from locutus.model.table import Table
-from locutus.model.terminology import Terminology
-from locutus.api import default_headers
+import json
 
 from bson import json_util
-import json
+from flask_restful import Resource
+
+from locutus.api import default_headers
+from locutus.model.table import Table
+from locutus.model.terminology import Terminology
 
 
 class TableProvenance(Resource):

--- a/src/locutus/api/sessions.py
+++ b/src/locutus/api/sessions.py
@@ -1,7 +1,8 @@
-from flask_restful import Resource
 from flask import request
-from locutus.model.exceptions import APIError, LackingUserID
+from flask_restful import Resource
+
 from locutus.api import default_headers
+from locutus.model.exceptions import APIError, LackingUserID
 
 
 class SessionStart(Resource):

--- a/src/locutus/api/study.py
+++ b/src/locutus/api/study.py
@@ -1,11 +1,12 @@
-from flask_restful import Resource
-from flask import request
-from locutus.model.study import Study as mStudyTerm
-from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
-from locutus.api import default_headers
+import json
 
 from bson import json_util
-import json
+from flask import request
+from flask_restful import Resource
+
+from locutus.api import default_headers
+from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
+from locutus.model.study import Study as mStudyTerm
 
 
 class Studies(Resource):

--- a/src/locutus/api/table.py
+++ b/src/locutus/api/table.py
@@ -1,15 +1,16 @@
-from flask_restful import Resource
-from flask import request
-from locutus.model.table import Table as mTable
-from locutus.model.provenance import Provenance
-from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
-from locutus.api import default_headers, get_editor
-from locutus.api.datadictionary import DataDictionaries
-from locutus.model.exceptions import APIError, LackingUserID
+import json
 from copy import deepcopy
 
 from bson import json_util
-import json
+from flask import request
+from flask_restful import Resource
+
+from locutus.api import default_headers, get_editor
+from locutus.api.datadictionary import DataDictionaries
+from locutus.model.exceptions import APIError, LackingUserID
+from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat
+from locutus.model.provenance import Provenance
+from locutus.model.table import Table as mTable
 
 
 class TableRenameCode(Resource):
@@ -44,7 +45,7 @@ class TableRenameCode(Resource):
             description_updates = {}
 
         var_list = sorted(
-            list(set(list(varname_updates.keys()) + list(description_updates.keys())))
+            set(list(varname_updates.keys()) + list(description_updates.keys()))
         )
 
         for var in var_list:

--- a/src/locutus/api/table_load.py
+++ b/src/locutus/api/table_load.py
@@ -24,8 +24,6 @@ _data_types = {
 
 
 def get_data_type(data_type):
-    global _data_types
-
     dtype = data_type.lower()
     if dtype in _data_types:
         print(f"Swapping {dtype} out for {_data_types[dtype]}")

--- a/src/locutus/api/table_mappings.py
+++ b/src/locutus/api/table_mappings.py
@@ -1,13 +1,14 @@
-from flask_restful import Resource
 from flask import request
+from flask_cors import cross_origin
+from flask_restful import Resource
+
 from locutus import normalize_ftd_placeholders
+from locutus.api import default_headers, get_editor
+from locutus.api.terminology_mappings import TerminologyMappings
+from locutus.model.coding import CodingMapping
+from locutus.model.exceptions import APIError, LackingUserID
 from locutus.model.table import Table
 from locutus.model.terminology import MappingUserInputModel
-from locutus.model.coding import CodingMapping
-from locutus.api.terminology_mappings import TerminologyMappings
-from flask_cors import cross_origin
-from locutus.model.exceptions import APIError, LackingUserID
-from locutus.api import default_headers, get_editor
 
 
 class TableMappings(Resource):

--- a/src/locutus/api/terminology.py
+++ b/src/locutus/api/terminology.py
@@ -1,11 +1,13 @@
-from flask_restful import Resource
-from flask import request
-from locutus.model.terminology import Terminology as Term
-from locutus.model.exceptions import APIError, LackingUserID
-from flask_cors import cross_origin
-from locutus.api import default_headers, get_editor
-from bson import json_util
 import json
+
+from bson import json_util
+from flask import request
+from flask_cors import cross_origin
+from flask_restful import Resource
+
+from locutus.api import default_headers, get_editor
+from locutus.model.exceptions import APIError, LackingUserID
+from locutus.model.terminology import Terminology as Term
 
 
 class TerminologyEdit(Resource):
@@ -92,12 +94,10 @@ class TerminologyRenameCode(Resource):
             description_updates = {}
 
         code_list = sorted(
-            list(
-                set(
-                    list(code_updates.keys())
-                    + list(display_updates.keys())
-                    + list(description_updates.keys())
-                )
+            set(
+                list(code_updates.keys())
+                + list(display_updates.keys())
+                + list(description_updates.keys())
             )
         )
         try:

--- a/src/locutus/api/terminology_mapping.py
+++ b/src/locutus/api/terminology_mapping.py
@@ -1,25 +1,29 @@
-from flask_restful import Resource
+import json
+
+from bson import json_util
 from flask import request
+from flask_cors import cross_origin
+from flask_restful import Resource
+
 from locutus import (
     normalize_ftd_placeholders,
 )
-from locutus.model.terminology import (
-    Terminology as Term,
-    MappingUserInputModel,
-)
-from locutus.model.coding import CodingMapping
+from locutus.api import default_headers, get_editor
 from locutus.api.terminology_mappings import TerminologyMappings
-from locutus.model.terminology_mapping import MappingRelationshipModel
+from locutus.model.coding import CodingMapping
 from locutus.model.exceptions import (
     APIError,
     CodeNotPresent,
     LackingRequiredParameter,
     LackingUserID,
 )
-from flask_cors import cross_origin
-from locutus.api import default_headers, get_editor
-from bson import json_util
-import json
+from locutus.model.terminology import (
+    MappingUserInputModel,
+)
+from locutus.model.terminology import (
+    Terminology as Term,
+)
+from locutus.model.terminology_mapping import MappingRelationshipModel
 
 
 class TerminologyMapping(Resource):

--- a/src/locutus/api/terminology_mappings.py
+++ b/src/locutus/api/terminology_mappings.py
@@ -1,11 +1,14 @@
-from flask_restful import Resource
-from flask import request
-from locutus import normalize_ftd_placeholders
-from locutus.model.terminology import Terminology as Term, MappingUserInputModel
-from locutus.model.exceptions import APIError, LackingUserID
-from locutus.api import default_headers, get_editor
-from bson import json_util
 import json
+
+from bson import json_util
+from flask import request
+from flask_restful import Resource
+
+from locutus import normalize_ftd_placeholders
+from locutus.api import default_headers, get_editor
+from locutus.model.exceptions import APIError, LackingUserID
+from locutus.model.terminology import MappingUserInputModel
+from locutus.model.terminology import Terminology as Term
 
 
 class TerminologyMappings(Resource):

--- a/src/locutus/api/user_input.py
+++ b/src/locutus/api/user_input.py
@@ -1,12 +1,14 @@
-from flask_restful import Resource
-from flask import request
-from locutus.model.terminology import Terminology as Term
-from locutus.model.table import Table
-from locutus.model.exceptions import APIError, CodeNotPresent, LackingUserID
-from locutus.api import default_headers, get_editor
-from locutus.model.user_input import UserInput
-from bson import json_util
 import json
+
+from bson import json_util
+from flask import request
+from flask_restful import Resource
+
+from locutus.api import default_headers, get_editor
+from locutus.model.exceptions import APIError, CodeNotPresent, LackingUserID
+from locutus.model.table import Table
+from locutus.model.terminology import Terminology as Term
+from locutus.model.user_input import UserInput
 
 
 class TerminologyUserInput(Resource, UserInput):

--- a/src/locutus/api/user_prefs.py
+++ b/src/locutus/api/user_prefs.py
@@ -7,7 +7,7 @@ class UserPrefOntoFilters(Resource):
     def get(self):
 
         try:
-            editor = get_editor({})
+            editor = get_editor({}, editor=None)
         except Exception:  # noqa: BLE001 - this endpoint must not fail regardless of cause
             editor = "Application Default"
         # For now, we will just return a constant

--- a/src/locutus/api/user_prefs.py
+++ b/src/locutus/api/user_prefs.py
@@ -1,4 +1,5 @@
 from flask_restful import Resource
+
 from locutus.api import get_editor
 
 
@@ -7,7 +8,7 @@ class UserPrefOntoFilters(Resource):
 
         try:
             editor = get_editor({})
-        except Exception:
+        except Exception:  # noqa: BLE001 - this endpoint must not fail regardless of cause
             editor = "Application Default"
         # For now, we will just return a constant
         return {editor: {"api_preference": {"ols": ["mondo", "hp", "maxo", "ncit"]}}}

--- a/src/locutus/app.py
+++ b/src/locutus/app.py
@@ -56,7 +56,7 @@ from locutus.sessions import SessionManager
 
 
 def create_app(config_filename=None):
-    llevel = os.getenv("LOCUTUS_LOGLEVEL", logging.WARN)
+    llevel = os.getenv("LOCUTUS_LOGLEVEL", logging.WARNING)
 
     setup_logging(level=llevel, log_file=None)
 

--- a/src/locutus/app.py
+++ b/src/locutus/app.py
@@ -227,12 +227,14 @@ def create_app(config_filename=None):
         if path.startswith("api/"):
             return "404 Not Found", 404
         else:
+            assert app.static_folder is not None
             return send_from_directory(app.static_folder, "index.html")
 
     @app.errorhandler(404)
     @cross_origin(allow_headers=["Content-Type"])
     def not_found(e):
         if e.get_response().status == "404 NOT FOUND":
+            assert app.static_folder is not None
             return send_from_directory(app.static_folder, "index.html")
 
         return (

--- a/src/locutus/model/__init__.py
+++ b/src/locutus/model/__init__.py
@@ -1,24 +1,22 @@
 # Follow KF with the use of nanoid for ID generation.
-from nanoid import generate
 from copy import deepcopy
 
-from pymongo import ASCENDING
 from marshmallow import Schema, fields, post_load
+from nanoid import generate
+from pymongo import ASCENDING
 
-from .global_id import GlobalID
-from .simple import Simple
-from .serializable import Serializable
 from .datadictionary import DataDictionary
+from .global_id import GlobalID
 from .reference import Reference
+from .serializable import Serializable
+from .simple import Simple
 from .study import Study
 from .table import Table
 from .terminology import Terminology
 
-import pdb
-
-resource_types = dict(
-    [(str(item.__name__), item) for k, item in Serializable._factory_workers.items()]
-)
+resource_types = {
+    str(item.__name__): item for k, item in Serializable._factory_workers.items()
+}
 
 
 simple_types = [

--- a/src/locutus/model/coding.py
+++ b/src/locutus/model/coding.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class BasicCoding:
-    def __init__(self, code, display, system, description=""):
+    def __init__(self, code, display, system, description: str | None = ""):
 
         if display is None:
             display = ""
@@ -141,7 +141,7 @@ class Coding(Simple, BasicCoding):
         code,
         display="",
         system=None,
-        description="",
+        description: str | None = "",
         rank=0,
         valid=True,
         id=None,
@@ -205,9 +205,7 @@ class Coding(Simple, BasicCoding):
             mapping = CodingMapping(**mp)
             self.mappings.append(mapping)
 
-        self.api_preferences = api_preferences
-        if self.api_preferences is None:
-            self.api_preferences = {}
+        self.api_preferences: dict = {} if api_preferences is None else api_preferences
 
         """
         if api_preferences is None:
@@ -326,7 +324,7 @@ class Coding(Simple, BasicCoding):
                 self.save()
 
                 Provenance.add_mapping_provenance(
-                    temrinology_id=self.terminology_id,
+                    terminology_id=self.terminology_id,
                     target_coding=self.code,
                     editor=editor,
                     action=Provenance.ChangeType.EditMapping,

--- a/src/locutus/model/coding.py
+++ b/src/locutus/model/coding.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 class BasicCoding:
-    def __init__(self, code, display, system, description: str | None = ""):
+    def __init__(self, code, display: str | None, system, description: str | None = ""):
 
         if display is None:
             display = ""
@@ -139,7 +139,7 @@ class Coding(Simple, BasicCoding):
         self,
         terminology_id,
         code,
-        display="",
+        display: str | None = "",
         system=None,
         description: str | None = "",
         rank=0,

--- a/src/locutus/model/coding.py
+++ b/src/locutus/model/coding.py
@@ -10,6 +10,8 @@ from locutus.model.provenance import Provenance
 
 from .simple import Simple
 
+logger = logging.getLogger(__name__)
+
 
 class BasicCoding:
     def __init__(self, code, display, system, description=""):
@@ -146,16 +148,18 @@ class Coding(Simple, BasicCoding):
         resource_type=None,
         editor=None,
         _id=None,
-        mappings=[],
+        mappings=None,
         api_preferences=None,
     ):
+        if mappings is None:
+            mappings = []
         if not isinstance(terminology_id, str) or not terminology_id.strip():
             raise ValueError("Term ID is required for all Codings.")
         if not isinstance(code, str) or not code.strip():
             raise ValueError("Code is a required string and cannot be empty.")
         if not isinstance(system, str) or not system.strip():
-            logging.error("Coding instantiated without a system")
-            logging.error(f"{terminology_id}/{_id}:{code} - {system} ")
+            logger.error("Coding instantiated without a system")
+            logger.error(f"{terminology_id}/{_id}:{code} - {system} ")
             raise ValueError("System is a required string and cannot be empty.")
 
         if _id is None:

--- a/src/locutus/model/datadictionary.py
+++ b/src/locutus/model/datadictionary.py
@@ -1,10 +1,10 @@
-from .serializable import Serializable
 from marshmallow import Schema, fields, post_load
 
-from locutus.model.reference import Reference
 from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat, basic_date
 from locutus.model.harmony_export import harmony_exporter as build_harmony_exporter
+from locutus.model.reference import Reference
 
+from .serializable import Serializable
 
 """
 A data-dictionary is a collection of tables that, together, describe the 
@@ -61,11 +61,9 @@ class DataDictionary(Serializable):
 
         treference = f"Table/{table_id}"
 
-        idx = 0
-        for tblref in self.tables:
+        for idx, tblref in enumerate(self.tables):
             if tblref.reference == treference:
                 matching_references.append(idx)
-            idx += 1
 
         if len(matching_references) > 0:
             for ref in matching_references:

--- a/src/locutus/model/exceptions.py
+++ b/src/locutus/model/exceptions.py
@@ -1,7 +1,8 @@
 import logging
 
-
 import locutus
+
+logger = logging.getLogger(__name__)
 
 
 class APIError(Exception):
@@ -25,7 +26,7 @@ class CodeAlreadyPresent(APIError):
         self.existing_coding = existing_coding
         self.terminology_id = terminology_id
         message = f"The code({self.code}) is already present in the terminology({terminology_id}). The existing display is ({self.existing_coding.display})."
-        logging.error(message)
+        logger.error(message)
         super().__init__(message, status_code=400)
 
 
@@ -36,7 +37,7 @@ class CodeNotPresent(APIError):
         code_index = locutus.get_code_index(code)
         # More info on code format(code vs code_index) can be found in get_code_index
         message = f"The code {self.code}, or possibly:{code_index}, is not present in the terminology({self.terminology_id})."
-        logging.error(message)
+        logger.error(message)
         super().__init__(message, status_code=404)
 
 
@@ -49,7 +50,7 @@ class InvalidValueError(APIError):
         self.value = value
         self.valid_values = valid_values
         message = f"Value({self.value}) is not valid. The value should be one of:({self.valid_values})"
-        logging.error(message)
+        logger.error(message)
         super().__init__(message, status_code=400)
 
 
@@ -61,7 +62,7 @@ class LackingUserID(APIError):
     def __init__(self, editor):
         self.editor = editor
         message = f"This action requires an editor or session! Current editor or user_id: ({self.editor})"
-        logging.error(message)
+        logger.error(message)
         super().__init__(message, status_code=400)
 
 
@@ -73,5 +74,5 @@ class LackingRequiredParameter(APIError):
     def __init__(self, param):
         self.param = param
         message = f"This action requires the parameter: '{self.param}'"
-        logging.error(message)
+        logger.error(message)
         super().__init__(message, status_code=400)

--- a/src/locutus/model/global_id.py
+++ b/src/locutus/model/global_id.py
@@ -1,8 +1,9 @@
-import locutus
-import locutus.model
-from typing import Optional
 from marshmallow import Schema, fields, post_load
 from nanoid import generate
+
+import locutus
+import locutus.model
+
 from .simple import Simple
 
 """
@@ -18,7 +19,6 @@ from .simple import Simple
 
 class GlobalID(Simple):
     _schema = None
-    global resource_types
 
     def __init__(
         self, resource_type, key, domain="", id=None, object_id=None, _id=None
@@ -111,7 +111,7 @@ class GlobalID(Simple):
         return [[("resource_type", 1), ("domain", 1), ("key", 1)]]
 
     class _Schema(Schema):
-        _parent: Optional[type] = None
+        _parent: type | None = None
         id = fields.Str()
         resource_type = fields.Str(required=True)
         key = fields.Str(required=True)

--- a/src/locutus/model/global_id.py
+++ b/src/locutus/model/global_id.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from marshmallow import Schema, fields, post_load
 from nanoid import generate
 
@@ -74,8 +76,8 @@ class GlobalID(Simple):
             .set(self.dump())
         )
 
-    def dump(self):
-        return self.__class__._get_schema().dump(self)
+    def dump(self) -> dict:
+        return cast(dict, self.__class__._get_schema().dump(self))
 
     @classmethod
     def load(cls, resource):

--- a/src/locutus/model/global_id.py
+++ b/src/locutus/model/global_id.py
@@ -1,4 +1,6 @@
 import locutus
+import locutus.model
+from typing import Optional
 from marshmallow import Schema, fields, post_load
 from nanoid import generate
 from .simple import Simple
@@ -41,7 +43,7 @@ class GlobalID(Simple):
             resource_type, key=key, domain=domain, return_instance=False
         )
 
-        if resource is not None:
+        if isinstance(resource, dict):
             if id is None:
                 self.id = resource["id"]
 
@@ -76,9 +78,9 @@ class GlobalID(Simple):
         return self.__class__._get_schema().dump(self)
 
     @classmethod
-    def load(self, resource):
+    def load(cls, resource):
         # We probably will want to use the schema to validate this first
-        self.__init__(**resource)
+        return cls(**resource)
 
     @classmethod
     def find(cls, resource_type, key=None, domain="", return_instance=True):
@@ -109,6 +111,7 @@ class GlobalID(Simple):
         return [[("resource_type", 1), ("domain", 1), ("key", 1)]]
 
     class _Schema(Schema):
+        _parent: Optional[type] = None
         id = fields.Str()
         resource_type = fields.Str(required=True)
         key = fields.Str(required=True)

--- a/src/locutus/model/harmony_export.py
+++ b/src/locutus/model/harmony_export.py
@@ -6,9 +6,9 @@ column headers and format.
 
 """
 
+from datetime import UTC, datetime
 from enum import StrEnum
-from datetime import datetime
-
+from typing import ClassVar
 
 FTD_DATE_FORMAT = "%Y-%m-%d"
 
@@ -35,8 +35,8 @@ def harmony_exporter(
 class HarmonyBase:
     # For any derived class that wants a different header, we'll
     # use the map to offset any differences
-    _header_map = {}
-    _header_base = [
+    _header_map: ClassVar[dict] = {}
+    _header_base: ClassVar[list] = [
         "study_title",
         "study_name",
         "study_id",
@@ -61,18 +61,14 @@ class HarmonyBase:
         self.data = []
 
     def header(self):
-        return [
-            self._header_map[col] if col in self._header_map else col
-            for col in self._header_base
-        ]
+        return [self._header_map.get(col, col) for col in self._header_base]
 
     def init_data(self):
         # use default column names unless there is a special mapping for it
         # in _header_map
-        if self.output_format == HarmonyOutputFormat.CSV:
-            if len(self.data) == 0:
-                self.data.append(self.header())
-                return self.data[0]
+        if self.output_format == HarmonyOutputFormat.CSV and len(self.data) == 0:
+            self.data.append(self.header())
+            return self.data[0]
 
         # for JSON files, we'll merge them into the objects
         # as properties so no header needed
@@ -126,7 +122,7 @@ class HarmonyBase:
 
 
 class WhistleHarmony(HarmonyBase):
-    _header_map = {
+    _header_map: ClassVar[dict] = {
         "source_text": "local code",
         "source_description": "text",
         "source_domain": "table_name",
@@ -149,5 +145,5 @@ class FtdHarmony(HarmonyBase):
 
 def basic_date(t=None):
     if t is None:
-        t = datetime.now()
+        t = datetime.now(UTC)
     return t.strftime(FTD_DATE_FORMAT)

--- a/src/locutus/model/lookups.py
+++ b/src/locutus/model/lookups.py
@@ -1,13 +1,16 @@
 import logging
 import os
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from typing import ClassVar
 
 from search_dragon.support import ftd_ontology_lookup
 
 import locutus
 import locutus.model.terminology
 from locutus.model.validation import validate_enums
+
+logger = logging.getLogger(__name__)
 
 
 class ResourceSingletonBase:
@@ -24,12 +27,12 @@ class ResourceSingletonBase:
             or a list of dictionaries (for collections).
     """
 
-    _instances = {}
+    _instances: ClassVar[dict] = {}
 
     def __new__(cls, resource_name, is_collection=False):
         """Ensure only one instance of each terminology or collection is created."""
         if (resource_name, is_collection) not in cls._instances:
-            instance = super(ResourceSingletonBase, cls).__new__(cls)
+            instance = super().__new__(cls)
             cls._instances[(resource_name, is_collection)] = instance
             instance.db = locutus.persistence()  # Initialize database client
             if is_collection:
@@ -61,7 +64,7 @@ class FTDConceptMapTerminology(ResourceSingletonBase):
 
     def __new__(cls):
         # Automatically pass the resource_name to the base class
-        return super(FTDConceptMapTerminology, cls).__new__(cls, cls.resource_name)
+        return super().__new__(cls, cls.resource_name)
 
     def get_cached_resource(self):
         """Access the FTD Concept Map terminology document."""
@@ -93,9 +96,7 @@ class OntologyAPICollection(ResourceSingletonBase):
         """
         Creates or retrieves the singleton instance for the OntologyAPI collection.
         """
-        return super(OntologyAPICollection, cls).__new__(
-            cls, cls.resource_name, is_collection=True
-        )
+        return super().__new__(cls, cls.resource_name, is_collection=True)
 
     def get_ontology_data(self, field):
         """Retrieve specific field data for each ontology object.
@@ -113,11 +114,10 @@ class OntologyAPICollection(ResourceSingletonBase):
                 if field in ontology_details:
                     ontology_data[ontology_code.upper()] = ontology_details[field]
 
-        logging.debug(f"ontology data {ontology_data}")
+        logger.debug(f"ontology data {ontology_data}")
         return ontology_data
 
     def get_ontology_keys(self):
-        """ """
         cached_data = self.get_cached_resource()
 
         for ontology_object in cached_data:
@@ -143,8 +143,8 @@ class FTDOntologyLookup:
         Path(__file__).parent / "../storage/data/references/ftd_ontology_lookup.csv"
     )
     _expiration_days = 90
-    stored_ontology_lookup = {}
-    reverse_lookup = {}
+    stored_ontology_lookup: ClassVar[dict] = {}
+    reverse_lookup: ClassVar[dict] = {}
 
     @staticmethod
     def is_expired(filepath, expiration_days):
@@ -153,8 +153,8 @@ class FTDOntologyLookup:
         """
         if not os.path.exists(filepath):
             return True
-        file_mtime = datetime.fromtimestamp(os.path.getmtime(filepath))
-        return datetime.now() - file_mtime > timedelta(days=expiration_days)
+        file_mtime = datetime.fromtimestamp(os.path.getmtime(filepath), tz=UTC)
+        return datetime.now(UTC) - file_mtime > timedelta(days=expiration_days)
 
     @classmethod
     def load_data_to_memory(cls):
@@ -173,7 +173,7 @@ class FTDOntologyLookup:
                 if system not in cls.reverse_lookup:
                     cls.reverse_lookup[system] = curie
 
-        logging.debug("Ontology data loaded into memory.")
+        logger.debug("Ontology data loaded into memory.")
 
     @classmethod
     def fetch_and_store_csv(cls):

--- a/src/locutus/model/lookups.py
+++ b/src/locutus/model/lookups.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import ClassVar
+from typing import Any, ClassVar
 
 from search_dragon.support import ftd_ontology_lookup
 
@@ -28,6 +28,12 @@ class ResourceSingletonBase:
     """
 
     _instances: ClassVar[dict] = {}
+
+    # Set in __new__ only (this class deliberately has no __init__, since
+    # cached singleton instances shouldn't be re-initialized on every "call").
+    db: Any
+    termref: Any
+    _cached_resource: Any
 
     def __new__(cls, resource_name, is_collection=False):
         """Ensure only one instance of each terminology or collection is created."""

--- a/src/locutus/model/onto_api_preference.py
+++ b/src/locutus/model/onto_api_preference.py
@@ -1,16 +1,17 @@
-from marshmallow import Schema, fields, post_load
-from locutus.model.exceptions import InvalidValueError
+from typing import ClassVar
+
 import search_dragon.search
+from marshmallow import Schema, fields, post_load
+
+from locutus.model.exceptions import InvalidValueError
 
 
 class OntoApiPreference:
-    available_apis = set(
-        [
-            key
-            for api_dict in search_dragon.search.SEARCH_APIS
-            for key, value in api_dict.items()
-        ]
-    )
+    available_apis: ClassVar[set] = {
+        key
+        for api_dict in search_dragon.search.SEARCH_APIS
+        for key, value in api_dict.items()
+    }
 
     def __init__(self, preferences=None):
 
@@ -20,7 +21,7 @@ class OntoApiPreference:
         for k in preferences:
             if k not in OntoApiPreference.available_apis:
                 raise InvalidValueError(
-                    k, valid_values=sorted(list(OntoApiPreference.available_apis))
+                    k, valid_values=sorted(OntoApiPreference.available_apis)
                 )
         self.api_preference = preferences
 

--- a/src/locutus/model/ontologies_search.py
+++ b/src/locutus/model/ontologies_search.py
@@ -116,6 +116,7 @@ class OntologyAPI(Serializable):
 
 
 class OntologyAPISearchModel:
+    @staticmethod
     def run_search_dragon(keywords, ontologies, apis, results_per_page, start_index):
         onto_seed_data = OntologyAPICollection()
         onto_data = onto_seed_data.get_ontology_data("system")

--- a/src/locutus/model/ontologies_search.py
+++ b/src/locutus/model/ontologies_search.py
@@ -122,7 +122,7 @@ class OntologyAPISearchModel:
 
         # Validate ontologies(FE provided) against expected ontologies(firestore)
         onto_curies = onto_seed_data.get_ontology_data("curie")
-        valid_curies = set([curie.upper() for curie in onto_curies.values()])
+        valid_curies = {curie.upper() for curie in onto_curies.values()}
         for onto in ontologies:
             if onto.upper() not in valid_curies:
                 raise InvalidValueError(

--- a/src/locutus/model/provenance.py
+++ b/src/locutus/model/provenance.py
@@ -1,8 +1,11 @@
+from datetime import UTC, datetime
 from enum import StrEnum
-from datetime import datetime
+
 from marshmallow import Schema, fields, post_load
-from .simple import Simple
+
 import locutus
+
+from .simple import Simple
 
 
 class DictOrStringField(fields.Field):
@@ -77,7 +80,7 @@ class Provenance(Simple):
         self.valid = valid
 
         if timestamp is None:
-            self.timestamp = datetime.now().strftime(
+            self.timestamp = datetime.now(UTC).strftime(
                 Provenance.PROVENANCE_TIMESTAMP_FORMAT
             )
 

--- a/src/locutus/model/reference.py
+++ b/src/locutus/model/reference.py
@@ -41,10 +41,12 @@ class Reference(Serializable):
         does cache this locally, but that shouldn't be trusted for more
         than a single block."""
         if self._reference is None:
+            assert self.reference is not None
             resource_type, id = self.reference.split("/")
             self._reference = Serializable.pull(resource_type, id)
 
         return self._reference
 
     def reference_id(self):
+        assert self.reference is not None
         return self.reference.split("/")[-1]

--- a/src/locutus/model/reference.py
+++ b/src/locutus/model/reference.py
@@ -1,6 +1,6 @@
-from .serializable import Serializable
 from marshmallow import Schema, fields, post_load
 
+from .serializable import Serializable
 
 """
 The reference just represents a placeholder for an entity from another table

--- a/src/locutus/model/serializable.py
+++ b/src/locutus/model/serializable.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any, ClassVar
 from nanoid import generate
 
 import locutus
@@ -6,10 +7,16 @@ import locutus.model.global_id
 
 
 class Serializable:
+    # Every concrete subclass defines its own marshmallow Schema and to_dict();
+    # left loosely typed here rather than constraining subclasses' exact shape.
+    _Schema: ClassVar[Any]
     _schema = None
     # Register each of our data_types with their corresponding class for
     # deserialization
     _factory_workers = {}
+
+    def to_dict(self) -> dict:
+        raise NotImplementedError
 
     def __init__(self, id=None, _id=None, collection_type=None, resource_type=None):
         self.id = id
@@ -82,6 +89,9 @@ class Serializable:
             # the global ID table altogether.
             # gid = locutus.model.global_id.GlobalID(resource_type=self.resource_type, key=":".join(self.keys()))
             # self.id = gid.id
+            assert self.resource_type is not None, (
+                "resource_type must be set before identify() is called"
+            )
             self.id = f"{locutus.model.resource_types[self.resource_type]._id_prefix}-{generate()}"
 
     def save(self):
@@ -89,9 +99,9 @@ class Serializable:
 
         if self._id is None and id is not None:
             id_matches = self.__class__.get(self.id, return_instance=False)
-            if id_matches is not None and len(id_matches) > 0:
-                if type(id_matches) is list:
-                    id_matches = id_matches[0]
+            if isinstance(id_matches, list) and len(id_matches) > 0:
+                id_matches = id_matches[0]
+            if isinstance(id_matches, dict):
                 self._id = id_matches["_id"]
 
         self._id = (
@@ -109,7 +119,7 @@ class Serializable:
         self.__init__(**resource)
 
     def all(self):
-        locutus.persistence().collection(self.resource_type).documents()
+        return self.__class__.get(id=None)
 
     # Returns 1 or more keys, the first of which is recognized as the primary
     # and all subsequent keys are useful lookups. The primary key is what is

--- a/src/locutus/model/serializable.py
+++ b/src/locutus/model/serializable.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, ClassVar, Literal, Self, overload
+from typing import Any, ClassVar, Literal, Self, cast, overload
 
 from nanoid import generate
 
@@ -122,8 +122,8 @@ class Serializable:
             .set(self.dump())
         )
 
-    def dump(self):
-        return self.__class__._get_schema().dump(self)
+    def dump(self) -> dict:
+        return cast(dict, self.__class__._get_schema().dump(self))
 
     def load(self, resource):
         # We probably will want to use the schema to validate this first

--- a/src/locutus/model/serializable.py
+++ b/src/locutus/model/serializable.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 from typing import Any, ClassVar
+
 from nanoid import generate
 
 import locutus
@@ -13,7 +14,7 @@ class Serializable:
     _schema = None
     # Register each of our data_types with their corresponding class for
     # deserialization
-    _factory_workers = {}
+    _factory_workers: ClassVar[dict] = {}
 
     def to_dict(self) -> dict:
         raise NotImplementedError

--- a/src/locutus/model/serializable.py
+++ b/src/locutus/model/serializable.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal, Self, overload
 
 from nanoid import generate
 
@@ -58,6 +58,16 @@ class Serializable:
         resource_class = cls._factory_workers[resource_type.lower()]
 
         return resource_class.get(id=id, return_instance=return_instance)
+
+    @overload
+    @classmethod
+    def get(cls, id: None = None, return_instance: bool = True) -> list[Any]: ...
+    @overload
+    @classmethod
+    def get(cls, id: str, return_instance: Literal[True] = True) -> Self | None: ...
+    @overload
+    @classmethod
+    def get(cls, id: str, return_instance: Literal[False]) -> dict | None: ...
 
     @classmethod
     def get(cls, id=None, return_instance=True):

--- a/src/locutus/model/simple.py
+++ b/src/locutus/model/simple.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any, ClassVar
+from typing import Any, ClassVar, cast
 
 from bson import ObjectId
 
@@ -83,8 +83,8 @@ class Simple:
         #     print(self.dump())
         #     print("--------------------------")
 
-    def dump(self):
-        return self.__class__._get_schema().dump(self)
+    def dump(self) -> dict:
+        return cast(dict, self.__class__._get_schema().dump(self))
 
     def load(self, resource):
         # We probably will want to use the schema to validate this first

--- a/src/locutus/model/simple.py
+++ b/src/locutus/model/simple.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from typing import Any, ClassVar
 
 import locutus
 
@@ -8,8 +9,14 @@ from bson import ObjectId
 class Simple:
     """Similar in some ways to serializables but these will be only retrievable by searches not by usable IDs"""
 
+    # Every concrete subclass defines its own marshmallow Schema and to_dict();
+    # left loosely typed here rather than constraining subclasses' exact shape.
+    _Schema: ClassVar[Any]
     _schema = None
     _factory_workers = {}
+
+    def to_dict(self) -> dict:
+        raise NotImplementedError
 
     def __init__(self, _id=None, id=None, collection_type=None, resource_type=None):
         self.id = id

--- a/src/locutus/model/simple.py
+++ b/src/locutus/model/simple.py
@@ -1,9 +1,9 @@
 from copy import deepcopy
 from typing import Any, ClassVar
 
-import locutus
-
 from bson import ObjectId
+
+import locutus
 
 
 class Simple:
@@ -13,7 +13,7 @@ class Simple:
     # left loosely typed here rather than constraining subclasses' exact shape.
     _Schema: ClassVar[Any]
     _schema = None
-    _factory_workers = {}
+    _factory_workers: ClassVar[dict] = {}
 
     def to_dict(self) -> dict:
         raise NotImplementedError

--- a/src/locutus/model/simple_reference.py
+++ b/src/locutus/model/simple_reference.py
@@ -1,6 +1,6 @@
-from .simple import Simple
 from marshmallow import Schema, fields, post_load
 
+from .simple import Simple
 
 """
 The reference just represents a placeholder for an entity from another table

--- a/src/locutus/model/simple_reference.py
+++ b/src/locutus/model/simple_reference.py
@@ -41,10 +41,12 @@ class SimpleReference(Simple):
         does cache this locally, but that shouldn't be trusted for more
         than a single block."""
         if self._reference is None:
+            assert self.reference is not None
             resource_type, id = self.reference.split("/")
             self._reference = Simple.pull(resource_type, id)
 
         return self._reference
 
     def reference_id(self):
+        assert self.reference is not None
         return self.reference.split("/")[-1]

--- a/src/locutus/model/study.py
+++ b/src/locutus/model/study.py
@@ -1,13 +1,12 @@
-from . import Serializable
 from marshmallow import Schema, fields, post_load
 
 from locutus.model.datadictionary import DataDictionary
-from locutus.model.table import Table
-from locutus.model.reference import Reference
-
 from locutus.model.harmony_export import HarmonyFormat, HarmonyOutputFormat, basic_date
 from locutus.model.harmony_export import harmony_exporter as build_harmony_exporter
+from locutus.model.reference import Reference
+from locutus.model.table import Table
 
+from . import Serializable
 
 """
 A Study represents a research study which will likely contain one or more
@@ -131,11 +130,9 @@ class Study(Serializable):
 
         treference = f"DataDictionary/{id}"
 
-        idx = 0
-        for ref in self.datadictionary:
+        for idx, ref in enumerate(self.datadictionary):
             if ref.reference == treference:
                 matching_references.append(idx)
-            idx += 1
 
         if len(matching_references) > 0:
             for ref in matching_references:

--- a/src/locutus/model/table.py
+++ b/src/locutus/model/table.py
@@ -13,6 +13,8 @@ from locutus.model.variable import Variable
 
 from . import Serializable
 
+logger = logging.getLogger(__name__)
+
 """
 A Table represents a collection of dataset "variables", typically organized
 as a list, such as one might find inside a CSV file.
@@ -56,14 +58,16 @@ class Table(Serializable):
         url=None,
         description=None,
         filename=None,
-        variables=[],
+        variables=None,
         terminology=None,
         resource_type="Table",
         editor=None,
     ):
-        logging.info(f"Creating new table: id={id}:_id={_id}")
+        if variables is None:
+            variables = []
+        logger.info(f"Creating new table: id={id}:_id={_id}")
         super().__init__(id=id, _id=_id, collection_type="Table", resource_type="Table")
-        logging.info(f"Table created: id={self.id}")
+        logger.info(f"Table created: id={self.id}")
 
         if locutus.strip_none(code) == "":
             code = locutus.strip_none(name)
@@ -86,7 +90,7 @@ class Table(Serializable):
         # This represents the "shadow" terminology that reflects the variable
         # names and descriptions associated with a given table.
         if terminology:
-            logging.info(f"Table reusing terminology: {terminology['reference']}")
+            logger.info(f"Table reusing terminology: {terminology['reference']}")
             self.terminology = Reference(reference=terminology["reference"])
         else:
             terminology = {
@@ -96,11 +100,11 @@ class Table(Serializable):
                 "codes": [],
             }
 
-            logging.info(f"Instantiating new terminology {terminology}")
+            logger.info(f"Instantiating new terminology {terminology}")
             t = Terminology(**terminology)
-            logging.info(f"Saving Table {name}")
+            logger.info(f"Saving Table {name}")
             t.save()
-            logging.info("Saved Completed")
+            logger.info("Saved Completed")
             print(
                 f"Creating Shadow Terminology for table: {self.name} -- Terminology ID: {t.id}"
             )
@@ -248,19 +252,20 @@ class Table(Serializable):
             # create an empty one if not. This may need to be moved into the
             # variable itself.
 
-            if v["data_type"] == "ENUMERATION":
-                if "enumerations" not in v or len(v["enumerations"]) < 1:
-                    # Create an empty terminology and create a reference to that
-                    # terminology
-                    t = Terminology(
-                        name=v["name"],
-                        description=v.get("description"),
-                        url=f"{self.url}/{v['name']}",
-                    )
-                    t.save()
+            if v["data_type"] == "ENUMERATION" and (
+                "enumerations" not in v or len(v["enumerations"]) < 1
+            ):
+                # Create an empty terminology and create a reference to that
+                # terminology
+                t = Terminology(
+                    name=v["name"],
+                    description=v.get("description"),
+                    url=f"{self.url}/{v['name']}",
+                )
+                t.save()
 
-                    reference = f"Terminology/{t.id}"
-                    v["enumerations"] = {"reference": reference}
+                reference = f"Terminology/{t.id}"
+                v["enumerations"] = {"reference": reference}
 
             v = Variable.deserialize(variable)
             self._insert_variable(v)
@@ -389,7 +394,7 @@ class Table(Serializable):
             return pref
 
         except Exception as e:
-            print(f"An error occurred while retrieving preferences: {str(e)}")
+            print(f"An error occurred while retrieving preferences: {e!s}")
             raise
 
     def add_or_update_pref(self, api_preference, code=None):
@@ -399,7 +404,7 @@ class Table(Serializable):
             )
 
         except Exception as e:
-            print(f"An error occurred while updating preferences: {str(e)}")
+            print(f"An error occurred while updating preferences: {e!s}")
             raise
 
     def remove_pref(self, code=None):
@@ -407,7 +412,7 @@ class Table(Serializable):
             message = self.terminology.dereference().remove_pref(code=code)
             return message
         except Exception as e:
-            print(f"An error occurred while updating preferences: {str(e)}")
+            print(f"An error occurred while updating preferences: {e!s}")
             raise
 
     def get_preferred_terminology(self):
@@ -461,7 +466,7 @@ class Table(Serializable):
             )
 
         except Exception as e:
-            print(f"An error occurred while updating preferences: {str(e)}")
+            print(f"An error occurred while updating preferences: {e!s}")
             raise
 
     def remove_preferred_terminology(self):
@@ -485,7 +490,7 @@ class Table(Serializable):
             self.terminology.dereference().remove_preferred_terminology()
 
         except Exception as e:
-            print(f"An error occurred while updating preferences: {str(e)}")
+            print(f"An error occurred while updating preferences: {e!s}")
             raise
 
     class _Schema(Schema):

--- a/src/locutus/model/terminology.py
+++ b/src/locutus/model/terminology.py
@@ -111,6 +111,9 @@ class Terminology(Serializable):
 
                         code = Coding(**code)
                 if ref is None:
+                    # By construction: if we get here, `code` was either
+                    # already a Coding instance, or just became one above.
+                    assert isinstance(code, Coding)
                     code.system = self.url
                     code.save()
                     ref = SimpleReference(f"Coding/{code.id}")
@@ -122,7 +125,7 @@ class Terminology(Serializable):
                         locutus.model.provenance.Provenance.ChangeType.AddTerm,
                         editor=editor,
                         target="self",
-                        new_value=code.code,
+                        new_value=ref.dereference().code,
                     )
             # Be sure to capture the references we just created
             self.save()
@@ -159,10 +162,8 @@ class Terminology(Serializable):
         ):
             prov.delete(hard_delete=hard_delete)
 
-        all_codings = locutus.model.coding.Coding.get(
-            terminology_id=self.id, valid_only=False
-        )
-        if type(all_codings) is locutus.model.coding.Coding:
+        all_codings = Coding.get(terminology_id=self.id, valid_only=False)
+        if type(all_codings) is Coding:
             all_codings = [all_codings]
 
         for coding in all_codings:
@@ -212,9 +213,7 @@ class Terminology(Serializable):
                 new_to_codes = False
             else:
                 # If it's not in codes, but it is in the database...
-                coding = locutus.model.coding.Coding.get(
-                    terminology_id=self.id, code=code
-                )
+                coding = Coding.get(terminology_id=self.id, code=code)
 
                 if coding == []:
                     coding = None
@@ -226,7 +225,7 @@ class Terminology(Serializable):
                     )
 
             # Finally, the code is not really new, so all we are doing is updating valid status
-            if coding is not None:
+            if isinstance(coding, Coding):
                 if coding.valid is False:
                     self.add_provenance(
                         locutus.model.provenance.Provenance.ChangeType.EditTerm,
@@ -345,24 +344,24 @@ class Terminology(Serializable):
                     new_values.append(f"description: {new_description}")
                     code.description = new_description
 
-                old_values = ",".join(old_values)
-                new_values = ",".join(new_values)
+                old_values_str = ",".join(old_values)
+                new_values_str = ",".join(new_values)
 
                 code.save()
                 self.save()
-                if new_values:
+                if new_values_str:
                     self.add_provenance(
                         change_type=locutus.model.provenance.Provenance.ChangeType.EditTerm,
                         target=original_code,
-                        old_value=old_values,
-                        new_value=new_values,
+                        old_value=old_values_str,
+                        new_value=new_values_str,
                         editor=editor,
                     )
                     self.add_provenance(
                         change_type=locutus.model.provenance.Provenance.ChangeType.EditTerm,
                         target="self",
-                        old_value=old_values,
-                        new_value=new_values,
+                        old_value=old_values_str,
+                        new_value=new_values_str,
                         editor=editor,
                     )
                     if original_code != new_code:
@@ -408,6 +407,8 @@ class Terminology(Serializable):
         if code is not None:
             # Ensure codes are not placeholders at this point.
             coding = self.get_coding(code)
+            if coding is None:
+                raise locutus.model.exceptions.CodeNotPresent(code, self.id)
 
             old_values = {"code": coding.code, "codes": coding.delete_mappings()}
 
@@ -754,6 +755,7 @@ class Terminology(Serializable):
 
 
 class MappingUserInputModel:
+    @staticmethod
     def generate_mapping_user_input(id, code, mapped_code, user_id):
         """Mappings may have user_input data stored seperate from the mapping itself.
         This function collects and formats the user_input data for a given mapping,
@@ -800,6 +802,7 @@ class MappingUserInputModel:
             "users_vote": user_vote,
         }
 
+    @staticmethod
     def get_mapping_votes_counts(mapping_votes):
         """Counts up and down votes for a given mapping"""
         return {

--- a/src/locutus/model/terminology.py
+++ b/src/locutus/model/terminology.py
@@ -17,6 +17,8 @@ from locutus.model.user_input import MappingConversation, MappingVote
 
 from .serializable import Serializable
 
+logger = logging.getLogger(__name__)
+
 """
 A terminology exists on its own within the project but can be referenced by
 variables as part of their data-type construction.
@@ -58,10 +60,14 @@ class Terminology(Serializable):
         description=None,
         codes=None,
         resource_type=None,
-        preferred_terminologies=[],
-        api_preferences={},
+        preferred_terminologies=None,
+        api_preferences=None,
         editor=None,
     ):
+        if preferred_terminologies is None:
+            preferred_terminologies = []
+        if api_preferences is None:
+            api_preferences = {}
         super().__init__(
             id=id, _id=_id, collection_type="Terminology", resource_type="Terminology"
         )
@@ -94,11 +100,11 @@ class Terminology(Serializable):
                         code["terminology_id"] = self.id
                         code["system"] = self.url
                         if self.url is None:
-                            logging.debug(
+                            logger.debug(
                                 "Attempting to assign "
                                 " as system from the following Terminology: "
                             )
-                            logging.debug(
+                            logger.debug(
                                 f"Terminology Name: {self.name}\tTerminology ID: {self.id}"
                             )
                             code["system"] = "-"
@@ -297,7 +303,7 @@ class Terminology(Serializable):
             )
         else:
             msg = f"The terminology, '{self.name}' ({self.id}), has no code, '{code}'"
-            logging.error(msg)
+            logger.error(msg)
             raise KeyError(msg)
 
     def rename_code(
@@ -415,7 +421,7 @@ class Terminology(Serializable):
             # coding.save()
 
             if len(old_values["codes"]) == 0:
-                logging.debug(
+                logger.debug(
                     f"Soft deleting mappings for code: {code}, Terminology: {self.name} but there were no mappings."
                 )
 
@@ -646,7 +652,7 @@ class Terminology(Serializable):
             else:
                 message = f"No coding found in {self.name} for code, {code}."
 
-        logging.debug(message)
+        logger.debug(message)
         return message
 
     def get_preferred_terminology(self):
@@ -717,7 +723,7 @@ class Terminology(Serializable):
         self.preferred_terminologies = []
         self.save()
 
-        logging.debug(message)
+        logger.debug(message)
         return message
 
     class _Schema(Schema):

--- a/src/locutus/model/terminology_mapping.py
+++ b/src/locutus/model/terminology_mapping.py
@@ -1,7 +1,7 @@
 from locutus import get_code_index
-from locutus.model.terminology import Coding
-from locutus.model.lookups import FTDConceptMapTerminology
 from locutus.api.terminology_mapping import TerminologyMappings
+from locutus.model.lookups import FTDConceptMapTerminology
+from locutus.model.terminology import Coding
 
 
 class MappingRelationshipModel:
@@ -29,7 +29,7 @@ class MappingRelationshipModel:
             )
 
         except Exception as e:
-            print(f"An error occurred while setting the mapping relationship: {str(e)}")
+            print(f"An error occurred while setting the mapping relationship: {e!s}")
             raise
 
         response = TerminologyMappings.get_mappings(id)

--- a/src/locutus/model/terminology_mapping.py
+++ b/src/locutus/model/terminology_mapping.py
@@ -20,6 +20,7 @@ class MappingRelationshipModel:
 
         # Mappings have been moved into the Coding:
         coding = Coding.get(terminology_id=id, code=code)
+        assert isinstance(coding, Coding)
 
         try:
             coding.set_mapping_relationship(

--- a/src/locutus/model/user_input.py
+++ b/src/locutus/model/user_input.py
@@ -9,9 +9,10 @@ Current Use:
 """
 
 from marshmallow import Schema, fields, post_load
+
 from locutus.api import generate_mapping_index, get_editor
-from locutus.sessions import SessionManager
 from locutus.model.exceptions import LackingUserID
+from locutus.sessions import SessionManager
 
 from .simple import Simple
 
@@ -88,7 +89,7 @@ class UserInput:
             existing_data["code"] = existing_data["source_code"]
             return existing_data
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - surfaces whatever failed to the caller
             return (
                 f"An error occurred while retrieving user input for {id} {resource_type} - {code}/{mapped_code}: {e}"
             ), 500
@@ -206,7 +207,7 @@ class UserInput:
             content["code"] = content["source_code"]
             return content
 
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001 - surfaces whatever failed to the caller
             return (
                 f"An error occurred while updating firestore {id} \
                     {resource_type} - {document_id}: {e}"

--- a/src/locutus/model/user_input.py
+++ b/src/locutus/model/user_input.py
@@ -8,6 +8,8 @@ Current Use:
 
 """
 
+from typing import Any
+
 from marshmallow import Schema, fields, post_load
 
 from locutus.api import generate_mapping_index, get_editor
@@ -20,10 +22,22 @@ USER_INPUT_CHAR_LIMIT = 1000
 
 
 class UserInput:
+    """Mixin used alongside Simple by concrete subclasses (MappingConversation,
+    MappingVote), which provide terminology_id/source_code/mapped_code and
+    Simple's find()/get()."""
+
+    terminology_id: Any
+    source_code: Any
+    mapped_code: Any
+
     def __init__(self, return_format, input_type, update_policy):
         self.return_format = return_format
         self.input_type = input_type
         self.update_policy = update_policy
+
+    @classmethod
+    def find(cls, *args, **kwargs) -> Any:
+        raise NotImplementedError
 
     @classmethod
     def get_input_class(cls, type):
@@ -373,8 +387,8 @@ class MappingConversation(Simple, UserInput):
 
         @post_load
         def build_mapping_conversations(self, data, **kwargs):
-            """Transforms deserialized data into a MappingConversations instance."""
-            return MappingConversation(data["mapping_conversations"])
+            """Transforms deserialized data into a MappingConversation instance."""
+            return MappingConversation(**data)
 
     def to_dict(self):
         """Converts the list of mapping conversations to a dictionary format.
@@ -527,7 +541,7 @@ class MappingVote(Simple, UserInput):
             Returns:
                 dict: A dictionary representation of the mapping votes.
             """
-            return MappingVote(data["mapping_votes"])
+            return MappingVote(**data)
 
     def to_dict(self):
         """Converts the list of mapping votes to a dictionary format."""

--- a/src/locutus/model/variable.py
+++ b/src/locutus/model/variable.py
@@ -59,7 +59,11 @@ class Variable:
         BOOLEAN = 6
         ENUMERATION = 7
 
-    def __init__(self, code="", name="", description=""):
+    # Every concrete subclass overrides this, both at the class level and
+    # again per-instance in its own __init__.
+    data_type: typing.Optional["Variable.DataType"] = None
+
+    def __init__(self, code="", name="", description: str | None = ""):
         """Default variable type is a basic string"""
         # super().__init__(self, "Variable", self.__class__.__name__)
         self.name = locutus.strip_none(name)
@@ -71,6 +75,8 @@ class Variable:
             self.code = self.name
 
     class _Schema(Schema):
+        _parent: type | None = None
+
         @post_load
         def build_variable(self, data, **kwargs):
             args = deepcopy(data)
@@ -85,6 +91,9 @@ class Variable:
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
+        assert cls.data_type is not None, (
+            f"{cls.__name__} must set a data_type class attribute"
+        )
         cls._factory_workers[cls.data_type.name.lower()] = cls
 
     @classmethod
@@ -137,7 +146,7 @@ class EnumerationVariable(Variable):
         # but if it comes in as None, we have to be careful.
         enums = enumerations
         if enums:
-            enums = enumerations.get("reference")
+            enums = enums.get("reference")
         else:
             raise ValueError(
                 f"{self.name}, {self.data_type} must be defined with a proper list of enumerations."
@@ -146,6 +155,12 @@ class EnumerationVariable(Variable):
 
     def get_mappings(self):
         t = self.get_terminology()
+        if not isinstance(t, Terminology):
+            # ValueError, not TypeError: the reference itself is stale/missing,
+            # not a caller passing the wrong argument type.
+            raise ValueError(  # noqa: TRY004
+                f"{self.name}'s enumerations reference a terminology that no longer exists."
+            )
         mappings = t.mappings()
 
         return mappings

--- a/src/locutus/model/variable.py
+++ b/src/locutus/model/variable.py
@@ -11,6 +11,7 @@ import locutus
 from locutus.model.reference import Reference
 from locutus.model.terminology import Terminology
 
+logger = logging.getLogger(__name__)
 
 """
 A Variable lives inside a table and doesn't exist as a unit on its own, thus
@@ -47,7 +48,7 @@ class Variable:
     _schema = None
     # Register each of our data_types with their corresponding class for
     # deserialization
-    _factory_workers = {}
+    _factory_workers: typing.ClassVar[dict] = {}
 
     class DataType(Enum):
         STRING = 1
@@ -98,9 +99,9 @@ class Variable:
             return cls._factory_workers[data["data_type"].lower()](**vardata)
         except ValueError:
             raise
-        except Exception:
-            logging.error(data)
-            logging.error("ERROR: An issue was encountered with the following data")
+        except Exception:  # noqa: BLE001 - deliberately wraps any failure as a domain error
+            logger.error(data)
+            logger.error("ERROR: An issue was encountered with the following data")
             raise InvalidVariableDefinition(data["name"], data)
 
     @classmethod
@@ -183,7 +184,9 @@ class DateVariable(Variable):
         super().__init__(code=code, name=name, description=description)
         self.data_type = Variable.DataType.DATE
         if date:
-            self.date = datetime.strptime(date, format)
+            # A calendar date with no time-of-day component; a timezone
+            # would be meaningless here, so this intentionally stays naive.
+            self.date = datetime.strptime(date, format)  # noqa: DTZ007
         else:
             self.date = None
         self.format = format
@@ -284,15 +287,13 @@ class IntegerVariable(Variable):
         if not isinstance(value, (int)):
             raise ValidationError(f"Integer expected, but, {value}, was found.")
 
-        if self.min is not None:
-            if value < self.min:
-                return ValidationError(
-                    f"Integer value, {value}, is lower than the specified minimum, {self.min}."
-                )
+        if self.min is not None and value < self.min:
+            return ValidationError(
+                f"Integer value, {value}, is lower than the specified minimum, {self.min}."
+            )
 
-        if self.max is not None:
-            if value > self.max:
-                return ValidationError(
-                    f"Integer value, {value}, is larger than the specified maximum, {self.max}."
-                )
+        if self.max is not None and value > self.max:
+            return ValidationError(
+                f"Integer value, {value}, is larger than the specified maximum, {self.max}."
+            )
         return IntegerVariable._validation_helper._validated(value)

--- a/src/locutus/sessions.py
+++ b/src/locutus/sessions.py
@@ -106,6 +106,7 @@ class SessionManager:
         else:
             return {"message": f"No active session. Session object: {session}"}, 404
 
+    @staticmethod
     def create_user_id(editor):
         """
         Attempts to retrieve the user ID from the session or the provided editor ID.
@@ -140,6 +141,7 @@ class SessionManager:
                 )
                 return None
 
+    @staticmethod
     def create_current_datetime():
         """
         Creates a formatted string of the current date and time.

--- a/src/locutus/sessions.py
+++ b/src/locutus/sessions.py
@@ -1,9 +1,18 @@
+import logging
+import secrets
+import tempfile
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from cachelib.file import FileSystemCache
 from flask import session
 from flask_session import Session
 
-import secrets
-from datetime import timedelta, datetime
-import logging
+logger = logging.getLogger(__name__)
+
+# Session cache lives outside the repo (system temp dir) so it never collides
+# with source files or gets mistaken for part of the project tree.
+SESSION_CACHE_DIR = Path(tempfile.gettempdir()) / "locutus_flask_session"
 
 
 class SessionManager:
@@ -20,8 +29,11 @@ class SessionManager:
         # Generates a secure 32-character hex key to encrypt session data
         self.app.config["SECRET_KEY"] = secrets.token_hex(16)
 
-        # Store session info on server filesystem
-        self.app.config["SESSION_TYPE"] = "filesystem"
+        # Store session info on server filesystem, outside the repo tree
+        self.app.config["SESSION_TYPE"] = "cachelib"
+        self.app.config["SESSION_CACHELIB"] = FileSystemCache(
+            cache_dir=str(SESSION_CACHE_DIR)
+        )
 
         # Extra security
         self.app.config["SESSION_COOKIE_HTTPONLY"] = True
@@ -45,8 +57,8 @@ class SessionManager:
         """
         if not affiliation:
             affiliation = "basic"
-        logging.info(f"Setting the session user_id to {user_id}")
-        logging.info(f"Setting the session affiliation to {affiliation}")
+        logger.info(f"Setting the session user_id to {user_id}")
+        logger.info(f"Setting the session affiliation to {affiliation}")
         session["user_id"] = user_id
         session["affiliation"] = affiliation
 
@@ -66,12 +78,12 @@ class SessionManager:
         else:
             # If no affiliation is recognized
             timeout_hours = 8
-        logging.info(f"Session timeout is being set for {timeout_hours} hours.")
+        logger.info(f"Session timeout is being set for {timeout_hours} hours.")
         self.app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(hours=timeout_hours)
 
     def terminate_session(self):
         user_id = session["user_id"]
-        logging.info(f"Terminating the Session for user:{user_id}")
+        logger.info(f"Terminating the Session for user:{user_id}")
         session.clear()
         return {"message": "Session terminated"}, 200
 
@@ -104,26 +116,26 @@ class SessionManager:
         """
         try:
             if "user_id" in session:
-                logging.info(f"The session is active. Session object: {session}")
+                logger.info(f"The session is active. Session object: {session}")
                 return session["user_id"]
             elif editor:
-                logging.info(
+                logger.info(
                     f"The session is not active. Falling back to the existing editor: {editor}"
                 )
                 return editor
             else:
-                logging.info(
+                logger.info(
                     f"The session is not active. There is no editor defined. editor: {editor}"
                 )
                 return None
         except RuntimeError:
             if editor:
-                logging.info(
+                logger.info(
                     f"The session is not active. Falling back to the existing editor: {editor}"
                 )
                 return editor
             else:
-                logging.info(
+                logger.info(
                     f"The session is not active. There is no editor defined. editor: {editor}"
                 )
                 return None
@@ -134,5 +146,5 @@ class SessionManager:
         Returns:
             str: The current date and time as a string.
         """
-        current_date = datetime.now().strftime("%b %d, %Y, %I:%M:%S.%f %p")
+        current_date = datetime.now(UTC).strftime("%b %d, %Y, %I:%M:%S.%f %p")
         return current_date

--- a/src/locutus/storage/__init__.py
+++ b/src/locutus/storage/__init__.py
@@ -7,12 +7,11 @@ local dev testing.
 
 """
 
-from collections import defaultdict
-from pathlib import Path
-from copy import deepcopy
 import json
-
-from os import getenv, environ
+from collections import defaultdict
+from copy import deepcopy
+from os import environ, getenv
+from pathlib import Path
 
 from locutus.storage.mongo import persistence
 

--- a/src/locutus/storage/firestore.py
+++ b/src/locutus/storage/firestore.py
@@ -1,9 +1,7 @@
-import firebase_admin
-from firebase_admin import credentials
-from firebase_admin import firestore
-
-
 import os
+
+import firebase_admin
+from firebase_admin import credentials, firestore
 
 _db = None
 

--- a/src/locutus/storage/mongo.py
+++ b/src/locutus/storage/mongo.py
@@ -33,7 +33,7 @@ class DocumentSnapshot:
         return this
 
     def delete(self):
-        self._collection.delete_one({"_id": ObjectId(self._doc_id)})
+        self._collection.delete_one({"_id": ObjectId(self.id)})
 
 
 class DocumentReference:
@@ -166,6 +166,9 @@ class CollectionReference:
 
     def list_documents(self, page_size):
         return [doc for doc in self.stream()]
+
+    def create_index(self, keys):
+        return self._collection.create_index(keys)
 
 
 def filter_uri(uri):

--- a/src/locutus/storage/mongo.py
+++ b/src/locutus/storage/mongo.py
@@ -2,10 +2,13 @@
 import logging
 import os
 import re
+from typing import ClassVar
 from urllib.parse import unquote, urlparse
 
 from bson import ObjectId
 from pymongo import MongoClient
+
+logger = logging.getLogger(__name__)
 
 uri_filter = re.compile(r"(mongodb:\/\/[^:]*:)([^@]*)(@)")
 
@@ -176,10 +179,10 @@ def filter_uri(uri):
 
 
 class FirestoreCompatibleClient:
-    logging.info("FirestoreCompatibleClient")
+    logger.info("FirestoreCompatibleClient")
     from locutus.model import resource_types, simple_types
 
-    allowed_collections = set(
+    allowed_collections: ClassVar[set] = set(
         list(resource_types.keys()) + simple_types + ["OntologyAPI"]
     )
 
@@ -191,7 +194,7 @@ class FirestoreCompatibleClient:
         parsed = urlparse(filter_uri(mongo_uri))
         db_name = unquote(parsed.path.lstrip("/")) if parsed.path else None
 
-        logging.info(f"Database name parsed: '{db_name}'")
+        logger.info(f"Database name parsed: '{db_name}'")
         if not db_name:
             raise ValueError("Database name must be specified in the Mongo URI path!")
         self.client = MongoClient(mongo_uri)
@@ -202,11 +205,11 @@ class FirestoreCompatibleClient:
                 raise ValueError(
                     f"The specified database, {db_name}, isn't present in the database. Available DBs include: {', '.join(self.client.list_database_names())}"
                 )
-            logging.error(f"Database, {db_name}, not currently found.")
+            logger.error(f"Database, {db_name}, not currently found.")
         self.db = self.client[db_name]
         self.db_name = db_name
         self.collection_list = self.db.list_collection_names()
-        logging.info(
+        logger.info(
             f"List of database collections in the connected DB: \n{', '.join(self.collection_list)}"
         )
 
@@ -216,7 +219,7 @@ class FirestoreCompatibleClient:
                 FirestoreCompatibleClient.allowed_collections
             )
             msg = f"{collection_name} is not present in the database. Available collections are:\n * {collection_names}"
-            logging.info(msg)
+            logger.info(msg)
 
             raise KeyError(msg)
         return CollectionReference(self.db[collection_name])

--- a/src/locutus/tests/__init__.py
+++ b/src/locutus/tests/__init__.py
@@ -1,4 +1,5 @@
 import pytest
+
 from locutus.app import create_app
 
 
@@ -7,6 +8,5 @@ def client():
     app = create_app()
     app.config["TESTING"] = True
 
-    with app.app_context():
-        with app.test_client() as client:
-            yield client
+    with app.app_context(), app.test_client() as client:
+        yield client

--- a/src/locutus/tests/api_load_table_test.py
+++ b/src/locutus/tests/api_load_table_test.py
@@ -1,7 +1,7 @@
-from . import client
-from .test_terminology import ftd_concept_relationships
 from locutus.model.table import Table
 
+from . import client
+from .test_terminology import ftd_concept_relationships
 
 mini_table_body = {
     "name": "mini table",
@@ -46,7 +46,6 @@ mini_table_body = {
 
 
 def test_loading_table(client, ftd_concept_relationships):
-    global mini_table_body
     response = client.post(
         "/api/LoadTable",
         json=mini_table_body,
@@ -77,8 +76,6 @@ def test_loading_table(client, ftd_concept_relationships):
 
 
 def test_loading_table_put(client, ftd_concept_relationships):
-    global mini_table_body
-
     original_table = Table(
         name="FTD Table 01",
         url="http://ftd.unit.tests/basic_table/01",

--- a/src/locutus/tests/api_ontology_api_test.py
+++ b/src/locutus/tests/api_ontology_api_test.py
@@ -1,7 +1,8 @@
 import pytest
 
-from . import client
 from locutus.model.ontologies_search import OntologyAPI
+
+from . import client
 
 
 @pytest.fixture

--- a/src/locutus/tests/api_study_test.py
+++ b/src/locutus/tests/api_study_test.py
@@ -1,7 +1,8 @@
+from locutus.model.study import Study
+
 from . import client
 from .test_study import basic_study
 from .test_terminology import sample_terminology
-from locutus.model.study import Study
 
 
 def test_study_none(client):

--- a/src/locutus/tests/api_table_test.py
+++ b/src/locutus/tests/api_table_test.py
@@ -1,7 +1,8 @@
+from locutus.model.table import Table
+
 from . import client
 from .test_table import basic_table
 from .test_terminology import sample_terminology
-from locutus.model.table import Table
 
 
 def test_table_get(client, sample_terminology, basic_table):

--- a/src/locutus/tests/api_terminology_test.py
+++ b/src/locutus/tests/api_terminology_test.py
@@ -55,7 +55,9 @@ def test_terminology_rename(client):
     )
     assert response.status_code == 201
 
-    term = Terminology.get("ontology-two").realize_as_dict()
+    term_obj = Terminology.get("ontology-two")
+    assert term_obj is not None
+    term = term_obj.realize_as_dict()
     assert term["codes"][0]["code"] == "Code01"
 
     response = client.patch(
@@ -71,6 +73,7 @@ def test_terminology_rename(client):
     assert response.status_code == 201
 
     term = Terminology.get("ontology-two")
+    assert term is not None
     assert term.codes[1].dereference().display == "second code"
     assert term.codes[1].dereference().description == "second desc"
 
@@ -211,6 +214,7 @@ def test_terminology_add_and_delete_code(client):
     assert len(term["codes"]) == 2
 
     coding = Coding.get(new_coding_id)
+    assert isinstance(coding, Coding)
     coding.delete()
 
     term = Terminology.get(term_id)

--- a/src/locutus/tests/api_terminology_test.py
+++ b/src/locutus/tests/api_terminology_test.py
@@ -1,8 +1,9 @@
+from locutus.model import GlobalID
+from locutus.model.coding import Coding
+from locutus.model.terminology import Terminology
+
 from . import client
 from .test_terminology import ftd_concept_relationships, sample_terminology
-from locutus.model.terminology import Terminology
-from locutus.model.coding import Coding
-from locutus.model import GlobalID
 
 
 def test_terminology_get(client, ftd_concept_relationships, sample_terminology):

--- a/src/locutus/tests/test_coding.py
+++ b/src/locutus/tests/test_coding.py
@@ -44,7 +44,7 @@ class TestCoding:
     def test_coding_initialization_required_fields(self):
         """Tests successful initialization with only required fields."""
         with pytest.raises(TypeError):
-            Coding(code="SNOMED", system="https://snomedct.org")
+            Coding(code="SNOMED", system="https://snomedct.org")  # pyright: ignore[reportCallIssue] - deliberately omits required terminology_id
 
         with pytest.raises(ValueError, match="Term ID is required for all Codings."):
             Coding(terminology_id="", code="SNOMED", system="https://snomedct.org")
@@ -76,11 +76,13 @@ class TestCoding:
             code=coding_one.code,
             valid_only=False,
         )
+        assert isinstance(coding, Coding)
         assert not coding.valid
         coding = Coding(terminology_id="term1", code="SNOMED", system="SNOMED CT")
         coding.save()
 
         c = Coding.get(code="SNOMED", system="SNOMED CT")
+        assert isinstance(c, Coding)
         assert c.code == coding.code
         assert c.terminology_id == coding.terminology_id
         coding.delete(hard_delete=True)
@@ -125,6 +127,7 @@ class TestCoding:
         assert len(codes) == 2
 
         code = Coding.get(system=coding_one.system, code=coding_one.code)
+        assert isinstance(code, Coding)
         assert code.code == coding_one.code
         assert code.system == coding_one.system
         assert code.terminology_id == coding_one.terminology_id
@@ -153,6 +156,7 @@ class TestCoding:
         db_copy = Coding.get(
             terminology_id=coding_one.terminology_id, code=coding_one.code
         )
+        assert isinstance(db_copy, Coding)
         assert len(db_copy.mappings) == 2
 
         assert db_copy.mappings[0].code == "MAP_C1_A"
@@ -166,6 +170,7 @@ class TestCoding:
         db_copy = Coding.get(
             terminology_id=coding_one.terminology_id, code=coding_one.code
         )
+        assert isinstance(db_copy, Coding)
         assert len(db_copy.mappings) == 1
         assert db_copy.mappings[0].code == "MAP_C1_B"
         assert db_copy.mappings[0].mapping_relationship == "equivalent"
@@ -176,6 +181,7 @@ class TestCoding:
         db_copy = Coding.get(
             terminology_id=coding_one.terminology_id, code=coding_one.code
         )
+        assert isinstance(db_copy, Coding)
         assert len(db_copy.mappings) == 0
 
     def test_coding_with_dots(self):
@@ -253,47 +259,47 @@ class TestCoding:
         )
         c11.save()
         c = Coding.get(terminology_id="term1", code=".")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "."
 
         c = Coding.get(terminology_id="term1", code="..")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == ".."
 
         c = Coding.get(terminology_id="term1", code=".term")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == ".term"
 
         c = Coding.get(terminology_id="term1", code="..term")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "..term"
 
         c = Coding.get(terminology_id="term1", code="/")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "/"
 
         c = Coding.get(terminology_id="term1", code="/slash")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "/slash"
 
         c = Coding.get(terminology_id="term1", code="slash/")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "slash/"
 
         c = Coding.get(terminology_id="term1", code="#")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "#"
 
         c = Coding.get(terminology_id="term1", code="#hash")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "#hash"
 
         c = Coding.get(terminology_id="term1", code="ha#sh")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "ha#sh"
 
         c = Coding.get(terminology_id="term1", code="hash#")
-        assert c is not None
+        assert isinstance(c, Coding)
         assert c.code == "hash#"
 
         codes = Coding.get(terminology_id="term1")

--- a/src/locutus/tests/test_coding.py
+++ b/src/locutus/tests/test_coding.py
@@ -1,10 +1,9 @@
 # test_coding.py
 import pytest
-from locutus.model.coding import Coding, CodingMapping
-from locutus import get_code_index
-
-
 from rich import print
+
+from locutus import get_code_index
+from locutus.model.coding import Coding, CodingMapping
 
 
 @pytest.fixture

--- a/src/locutus/tests/test_datadictionary.py
+++ b/src/locutus/tests/test_datadictionary.py
@@ -1,9 +1,10 @@
 import pytest
 
+from locutus.model.datadictionary import DataDictionary
+
 from .test_study import basic_study
 from .test_table import basic_table
 from .test_terminology import sample_terminology
-from locutus.model.datadictionary import DataDictionary
 
 
 @pytest.fixture

--- a/src/locutus/tests/test_global_id.py
+++ b/src/locutus/tests/test_global_id.py
@@ -1,4 +1,5 @@
 import pytest
+
 from locutus.model import GlobalID
 
 

--- a/src/locutus/tests/test_global_id.py
+++ b/src/locutus/tests/test_global_id.py
@@ -123,6 +123,7 @@ def test_global_id_creation_minimal():
 
     assert gid.resource_type == "DataDictionary"
     assert gid.key == "LOINC"
+    assert gid.id is not None
     assert gid.id[0:3] == "dd-"
     assert gid.object_id is None
     gid.delete()

--- a/src/locutus/tests/test_provenance.py
+++ b/src/locutus/tests/test_provenance.py
@@ -1,7 +1,7 @@
-from locutus.model.provenance import Provenance
-from datetime import datetime
-
+from datetime import UTC, datetime, timezone
 from time import sleep
+
+from locutus.model.provenance import Provenance
 
 
 class TestProvenance:
@@ -26,7 +26,7 @@ class TestProvenance:
         )
         assert p2.timestamp is not None
 
-        t1 = datetime.now().strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
+        t1 = datetime.now(UTC).strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
         sleep(0.1)
         p3 = Provenance.add_terminology_provenance(
             terminology_id="tm-0000001",
@@ -107,9 +107,9 @@ class TestProvenance:
 
     def test_prov_order(self):
         # Create 2 timestamps with some delay between them
-        t1 = datetime.now().strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
+        t1 = datetime.now(UTC).strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
         sleep(0.1)
-        t2 = datetime.now().strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
+        t2 = datetime.now(UTC).strftime(Provenance.PROVENANCE_TIMESTAMP_FORMAT)
         sleep(0.1)
 
         p2 = Provenance(

--- a/src/locutus/tests/test_table.py
+++ b/src/locutus/tests/test_table.py
@@ -1,9 +1,10 @@
 import pytest
 
-from .test_terminology import sample_terminology
 from locutus.model.table import Table
 from locutus.model.terminology import Terminology
 from locutus.model.variable import Variable
+
+from .test_terminology import sample_terminology
 
 
 @pytest.fixture

--- a/src/locutus/tests/test_table.py
+++ b/src/locutus/tests/test_table.py
@@ -42,7 +42,8 @@ def basic_table(sample_terminology):
 
     t = Terminology.get(table.terminology.reference_id())
     # t.global_id().delete()
-    t.delete(hard_delete=True)
+    if t is not None:
+        t.delete(hard_delete=True)
 
     table.delete(hard_delete=True)
 

--- a/src/locutus/tests/test_terminology.py
+++ b/src/locutus/tests/test_terminology.py
@@ -674,7 +674,7 @@ def test_mapping_relationship(ftd_concept_relationships, sample_terminology):
             system="http://map.com/A",
             mapping_relationship="",
         )
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001 - fail the test clearly on any unexpected error
         raise pytest.fail(
             f"There was a problem with acceptable mapping relationships: {e}"
         )

--- a/src/locutus/tests/test_terminology.py
+++ b/src/locutus/tests/test_terminology.py
@@ -133,6 +133,7 @@ def test_terminology_id(sample_terminology):
         description="A sample oncology terminology",
     )
 
+    assert term.id is not None
     assert term.id[0:3] == "tm-"
     # term.global_id().delete()
     term.delete()

--- a/src/locutus/tests/test_terminology_prefs.py
+++ b/src/locutus/tests/test_terminology_prefs.py
@@ -1,8 +1,8 @@
 import pytest
 
-from .test_terminology import ftd_concept_relationships, sample_terminology
 from locutus.model.terminology import Terminology
 
+from .test_terminology import ftd_concept_relationships, sample_terminology
 
 _all_terms = None
 

--- a/src/locutus/tests/test_user_input.py
+++ b/src/locutus/tests/test_user_input.py
@@ -57,7 +57,7 @@ def create_user_input(
     code="C1",
     mapped_code="MAPPED_CODE",
 ):
-    return UserInput.create_or_replace_user_input(
+    result = UserInput.create_or_replace_user_input(
         resource_type="Terminology",
         collection_type="user_input",
         id=terminology_id,
@@ -67,20 +67,11 @@ def create_user_input(
         input_value=input_value,
         editor=editor,
     )
+    assert isinstance(result, dict)
+    return result
 
 
 class TestMappingConversations:
-    def get_input_class(self, type):
-        """
-        Returns the appropriate UserInput subclass for the given type.
-        """
-        if type == "mapping_conversations":
-            return MappingConversation()
-        elif type == "mapping_votes":
-            return MappingVote()
-        else:
-            raise ValueError("Invalid input type specified.")
-
     def test_duplicate_votes(self, sample_terminology):
         mv1 = MappingVote(
             terminology_id=sample_terminology.id,
@@ -218,6 +209,7 @@ class TestMappingConversations:
             mapped_code="MAPPED_CODE",
             type="mapping_conversations",  # "mapping_votes"
         )
+        assert isinstance(uitotal, dict)
         assert len(uitotal["mapping_conversations"]) == 3
         assert uitotal["mapped_code"] == "MAPPED_CODE"
         assert uitotal["code"] == "C1"
@@ -239,6 +231,7 @@ class TestMappingConversations:
             mapped_code="MAPPED_CODE",
             type="mapping_conversations",  # "mapping_votes"
         )
+        assert isinstance(uitotal, dict)
         assert "message" in uitotal
         assert uitotal["message"] == "No user input for this mapping."
 
@@ -287,6 +280,7 @@ class TestMappingConversations:
             mapped_code="MAPPED_CODE",
             type="mapping_votes",  # "mapping_votes"
         )
+        assert isinstance(uitotal, dict)
         assert len(uitotal["mapping_votes"]) == 2
         assert uitotal["mapped_code"] == "MAPPED_CODE"
         assert uitotal["code"] == "C1"
@@ -308,5 +302,6 @@ class TestMappingConversations:
             mapped_code="MAPPED_CODE",
             type="mapping_votes",  # "mapping_votes"
         )
+        assert isinstance(uitotal, dict)
         assert "message" in uitotal
         assert uitotal["message"] == "No user input for this mapping."

--- a/src/locutus/tests/test_user_input.py
+++ b/src/locutus/tests/test_user_input.py
@@ -2,7 +2,7 @@ import pytest
 
 from locutus.model.coding import Coding, CodingMapping
 from locutus.model.terminology import Terminology
-from locutus.model.user_input import UserInput, MappingConversation, MappingVote
+from locutus.model.user_input import MappingConversation, MappingVote, UserInput
 
 
 @pytest.fixture

--- a/src/locutus/utility/sideload.py
+++ b/src/locutus/utility/sideload.py
@@ -12,6 +12,8 @@ from locutus.model.exceptions import APIError, LackingRequiredParameter
 from locutus.model.table import Table
 from locutus.model.variable import Variable
 
+logger = logging.getLogger(__name__)
+
 
 def GetTerminology(table, source_variable, source_enum):
     if source_enum == source_variable:
@@ -46,17 +48,16 @@ def SetMappings(mapping_entries):
 
     _cur_table = None
 
-    mappings = dict()
+    mappings = {}
 
     # Let's verify the prov is present for all of them before starting
     # just to prevent having duplicates if some do have prov at the start
     for row in mapping_entries:
         source_variable = row["source_variable"]
         source_enumeration = row["source_enumeration"]
-        if row["provenance"].strip() == "":
-            # We will try to tolerate empty lines
-            if row["source_variable"].strip() != "":
-                raise LackingRequiredParameter("provenance")
+        # We will try to tolerate empty lines
+        if row["provenance"].strip() == "" and row["source_variable"].strip() != "":
+            raise LackingRequiredParameter("provenance")
 
         # If we are trying to map to nothing, then we have a problem
         if (
@@ -71,7 +72,7 @@ def SetMappings(mapping_entries):
             _cur_table = Table.get(row["table_id"])
 
         if _cur_table is None:
-            logging.error(f"Unable to find a table with the ID, {row['table_id']}")
+            logger.error(f"Unable to find a table with the ID, {row['table_id']}")
             raise APIError(f"unable to find table with the ID, {row['table_id']}")
 
         source_variable = row["source_variable"]
@@ -89,8 +90,8 @@ def SetMappings(mapping_entries):
 
                 try:
                     source_enumeration = var.code
-                except Exception:
-                    logging.error(f"{_cur_table.id} has no variable, {source_variable}")
+                except Exception:  # noqa: BLE001 - best-effort CSV row processing, log and continue
+                    logger.error(f"{_cur_table.id} has no variable, {source_variable}")
 
             key = f"{term.id}-{source_enumeration}"
             if key not in mappings:


### PR DESCRIPTION
Changes based on errors identified by basedpyright: 

- storage/mongo.py: added CollectionReference.create_index() (was missing, needed by Simple.create_indexes()), and fixed DocumentSnapshot.delete() referencing self._doc_id instead of self.id.
- model/simple.py / model/serializable.py: declared _Schema/to_dict on the base classes so pyright knows subclasses are expected to provide them.
- model/serializable.py: fixed all() (was calling a nonexistent method), added a resource_type assertion in identify(), and switched some None/list/dict narrowing to isinstance checks.
- model/global_id.py: fixed a circular-import-safe access pattern, fixed GlobalID.load() (was broken if ever called), typed _parent properly, and applied the same narrowing fix as serializable.py.